### PR TITLE
Make pass ids reproducable

### DIFF
--- a/app/schemas/nz.eloque.foss_wallet.persistence.WalletDb/6.json
+++ b/app/schemas/nz.eloque.foss_wallet.persistence.WalletDb/6.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 5,
+    "version": 6,
     "identityHash": "cdc58bba0fe3547bf4a9618d3aa4eb4f",
     "entities": [
       {

--- a/app/src/main/java/nz/eloque/foss_wallet/model/Pass.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/Pass.kt
@@ -28,7 +28,7 @@ data class PassField(val key: String, val label: String, val value: String) {
 
 @Entity(tableName = "Pass")
 data class Pass(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0L,
+    @PrimaryKey val id: Long = 0L,
     var description: String,
     val formatVersion: Int,
     val organization: String,

--- a/app/src/main/java/nz/eloque/foss_wallet/parsing/PassParser.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/parsing/PassParser.kt
@@ -18,6 +18,7 @@ import org.json.JSONException
 import org.json.JSONObject
 import java.time.ZonedDateTime
 import java.time.format.DateTimeParseException
+import java.util.Objects
 
 class PassParser(val context: Context) {
 
@@ -44,6 +45,7 @@ class PassParser(val context: Context) {
         val serialNumber = passJson.getString("serialNumber")
         return Triple(
             Pass(
+                id = Objects.hash(serialNumber, organizationName).toLong(),
                 description = description,
                 formatVersion = passVersion,
                 organization = organizationName,

--- a/app/src/main/java/nz/eloque/foss_wallet/persistence/WalletDb.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/persistence/WalletDb.kt
@@ -13,10 +13,11 @@ import nz.eloque.foss_wallet.persistence.pass.PassDao
 
 
 @Database(
-    version = 5,
+    version = 6,
     entities = [Pass::class, PassLocalization::class],
     autoMigrations = [
-        AutoMigration (from = 4, to = 5)
+        AutoMigration (from = 4, to = 5),
+        AutoMigration (from = 5, to = 6),
     ],
     exportSchema = true
 )


### PR DESCRIPTION
Pass ids are now created from the combined hash of the pass's serialNumber and organizationName