### PR TITLE
Render date fields in a nice way

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/model/Pass.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/Pass.kt
@@ -5,34 +5,12 @@ import android.location.Location
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import nz.eloque.foss_wallet.model.field.PassField
 import nz.eloque.foss_wallet.utils.inIgnoreCase
-import org.json.JSONObject
 import java.io.File
 import java.time.Instant
 import java.util.LinkedList
 import java.util.UUID
-
-
-@Entity
-data class PassField(val key: String, val label: String, val value: String) {
-    fun toJson(): JSONObject {
-        return JSONObject().also {
-            it.put("key", key)
-            it.put("label", label)
-            it.put("value", value)
-        }
-    }
-
-    fun contains(query: String): Boolean {
-        return query inIgnoreCase this.label || query inIgnoreCase this.value
-    }
-
-    companion object {
-        fun fromJson(json: JSONObject): PassField {
-            return PassField(json.getString("key"), json.getString("label"), json.getString("value"))
-        }
-    }
-}
 
 @Entity(tableName = "Pass")
 data class Pass(

--- a/app/src/main/java/nz/eloque/foss_wallet/model/Pass.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/Pass.kt
@@ -99,6 +99,6 @@ data class Pass(
     }
 
     fun MutableList<PassField>.contains(query: String): Boolean {
-        return this.any { query in it.label || query in it.value }
+        return this.any { query in it.label || it.content.contains(query) }
     }
 }

--- a/app/src/main/java/nz/eloque/foss_wallet/model/PassWithLocalization.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/PassWithLocalization.kt
@@ -2,6 +2,7 @@ package nz.eloque.foss_wallet.model
 
 import androidx.room.Embedded
 import androidx.room.Relation
+import nz.eloque.foss_wallet.model.field.PassField
 
 data class PassWithLocalization(
     @Embedded

--- a/app/src/main/java/nz/eloque/foss_wallet/model/field/PassContent.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/field/PassContent.kt
@@ -1,0 +1,82 @@
+package nz.eloque.foss_wallet.model.field
+
+import nz.eloque.foss_wallet.utils.inIgnoreCase
+import nz.eloque.foss_wallet.utils.prettyDate
+import nz.eloque.foss_wallet.utils.prettyDateTime
+import nz.eloque.foss_wallet.utils.prettyTime
+import java.time.Instant
+import java.time.format.FormatStyle
+
+sealed class PassContent(val id: Int) {
+
+    class Plain(val text: String) : PassContent(PLAIN) {
+        override fun contains(query: String) = query inIgnoreCase text
+        override fun prettyPrint(): String = text
+    }
+
+    class Currency(val amount: String, val currency: String) : PassContent(CURRENCY) {
+        override fun contains(query: String) = query inIgnoreCase amount || query inIgnoreCase currency
+        override fun prettyPrint(): String = amount + toCurrency(currency)
+
+        private fun toCurrency(currencyCode: String): String? {
+            return try {
+                java.util.Currency.getInstance(currency).symbol
+            } catch (_: IllegalArgumentException) {
+                " $currencyCode"
+            }
+        }
+    }
+
+    data class Date(val date: String, val format: FormatStyle) : PassContent(DATE) {
+        override fun contains(query: String) = query inIgnoreCase date
+        override fun prettyPrint(): String  = Instant.parse(date).prettyDate(format)
+    }
+
+    data class Time(val time: String, val format: FormatStyle) : PassContent(TIME) {
+        override fun contains(query: String) = query inIgnoreCase time
+        override fun prettyPrint(): String  = Instant.parse(time).prettyTime(format)
+    }
+
+    data class DateTime(val dateTime: String, val format: FormatStyle) : PassContent(DATE_TIME) {
+        override fun contains(query: String) = query inIgnoreCase dateTime
+        override fun prettyPrint(): String  = Instant.parse(dateTime).prettyDateTime(format)
+    }
+
+
+    companion object {
+        const val PLAIN = 0
+        const val CURRENCY = 1
+        const val DATE = 2
+        const val TIME = 3
+        const val DATE_TIME = 4
+
+        fun deserialize(content: String): PassContent {
+            return if (content[0].isDigit()) {
+                val id = content[0].digitToInt()
+                val content = content.substring(2)
+                return when(id) {
+                    CURRENCY -> content.split("|").let { Currency(it[0], it[1]) }
+                    DATE -> content.split("|").let { Date(it[0], FormatStyle.valueOf(it[1])) }
+                    TIME -> content.split("|").let { Time(it[0], FormatStyle.valueOf(it[1])) }
+                    DATE_TIME -> content.split("|").let { DateTime(it[0], FormatStyle.valueOf(it[1])) }
+                    else -> Plain(content)
+                }
+            } else {
+                Plain(content)
+            }
+        }
+    }
+
+    fun serialize(): String {
+        return when (this) {
+            is Plain -> this.id.toString() + "|" + this.text
+            is Currency -> this.id.toString() + "|" + this.amount + "|" + this.currency
+            is Date -> this.id.toString() + "|" + this.date + "|" + this.format.name
+            is Time -> this.id.toString() + "|" + this.time + "|" + this.format.name
+            is DateTime -> this.id.toString() + "|" + this.dateTime + "|" + this.format.name
+        }
+    }
+
+    abstract fun contains(query: String): Boolean
+    abstract fun prettyPrint(): String
+}

--- a/app/src/main/java/nz/eloque/foss_wallet/model/field/PassField.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/field/PassField.kt
@@ -9,23 +9,23 @@ import org.json.JSONObject
 data class PassField(
     val key: String,
     val label: String,
-    val value: String,
+    val content: PassContent,
 ) {
     fun toJson(): JSONObject {
         return JSONObject().also {
             it.put("key", key)
             it.put("label", label)
-            it.put("value", value)
+            it.put("value", content.serialize())
         }
     }
 
     fun contains(query: String): Boolean {
-        return query inIgnoreCase this.label || query inIgnoreCase this.value
+        return query inIgnoreCase this.label || this.content.contains(query)
     }
 
     companion object {
         fun fromJson(json: JSONObject): PassField {
-            return PassField(json.getString("key"), json.getString("label"), json.getString("value"))
+            return PassField(json.getString("key"), json.getString("label"), PassContent.deserialize(json.getString("value")))
         }
     }
 }

--- a/app/src/main/java/nz/eloque/foss_wallet/model/field/PassField.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/field/PassField.kt
@@ -1,0 +1,31 @@
+package nz.eloque.foss_wallet.model.field
+
+import androidx.room.Entity
+import nz.eloque.foss_wallet.utils.inIgnoreCase
+import org.json.JSONObject
+
+
+@Entity
+data class PassField(
+    val key: String,
+    val label: String,
+    val value: String,
+) {
+    fun toJson(): JSONObject {
+        return JSONObject().also {
+            it.put("key", key)
+            it.put("label", label)
+            it.put("value", value)
+        }
+    }
+
+    fun contains(query: String): Boolean {
+        return query inIgnoreCase this.label || query inIgnoreCase this.value
+    }
+
+    companion object {
+        fun fromJson(json: JSONObject): PassField {
+            return PassField(json.getString("key"), json.getString("label"), json.getString("value"))
+        }
+    }
+}

--- a/app/src/main/java/nz/eloque/foss_wallet/parsing/FieldParser.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/parsing/FieldParser.kt
@@ -1,0 +1,34 @@
+package nz.eloque.foss_wallet.parsing
+
+import nz.eloque.foss_wallet.model.field.PassContent
+import nz.eloque.foss_wallet.model.field.PassField
+import org.json.JSONObject
+import java.time.format.FormatStyle
+
+object FieldParser {
+
+    fun parse(field: JSONObject): PassField {
+        val key = field.getString("key")
+        val label = field.getString("label")
+        val value = field.getString("value")
+
+        val content = when {
+            field.has("currencyCode") -> PassContent.Currency(value, field.getString("currencyCode"))
+            field.has("dateStyle") && field.getString("dateStyle") != "PKDateStyleNone" -> PassContent.Date(value, field.getString("dateStyle").toFormatStyle())
+            field.has("timeStyle") && field.getString("timeStyle") != "PKDateStyleNone" -> PassContent.Time(value, field.getString("timeStyle").toFormatStyle())
+            else -> PassContent.Plain(value)
+        }
+
+        return PassField(key, label, content)
+    }
+
+    private fun String.toFormatStyle(): FormatStyle {
+        return when (this) {
+            "PKDateStyleShort" -> FormatStyle.SHORT
+            "PKDateStyleMedium" -> FormatStyle.MEDIUM
+            "PKDateStyleLong" -> FormatStyle.LONG
+            "PKDateStyleFull" -> FormatStyle.FULL
+            else -> FormatStyle.FULL
+        }
+    }
+}

--- a/app/src/main/java/nz/eloque/foss_wallet/parsing/PassParser.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/parsing/PassParser.kt
@@ -9,9 +9,9 @@ import nz.eloque.foss_wallet.R
 import nz.eloque.foss_wallet.model.BarCode
 import nz.eloque.foss_wallet.model.Pass
 import nz.eloque.foss_wallet.model.PassColors
-import nz.eloque.foss_wallet.model.PassField
 import nz.eloque.foss_wallet.model.PassType
 import nz.eloque.foss_wallet.model.TransitType
+import nz.eloque.foss_wallet.model.field.PassField
 import nz.eloque.foss_wallet.persistence.InvalidPassException
 import nz.eloque.foss_wallet.persistence.PassBitmaps
 import nz.eloque.foss_wallet.utils.Hash

--- a/app/src/main/java/nz/eloque/foss_wallet/parsing/PassParser.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/parsing/PassParser.kt
@@ -179,13 +179,8 @@ class PassParser(val context: Context? = null) {
     private fun JSONObject.collectFields(name: String, fieldContainer: MutableList<PassField>) {
         try {
             this.getJSONArray(name).forEach {
-                fieldContainer.add(
-                    PassField(
-                        it.getString("key"),
-                        it.getString("label"),
-                        it.getString("value")
-                    )
-                )
+                val passField = FieldParser.parse(it)
+                fieldContainer.add(passField)
             }
         } catch (_: JSONException) {
             Log.i(TAG, "Fields $name not existing. Stopping parsing.")

--- a/app/src/main/java/nz/eloque/foss_wallet/persistence/TypeConverters.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/persistence/TypeConverters.kt
@@ -6,9 +6,9 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.room.TypeConverter
 import nz.eloque.foss_wallet.model.BarCode
 import nz.eloque.foss_wallet.model.PassColors
-import nz.eloque.foss_wallet.model.PassField
 import nz.eloque.foss_wallet.model.PassType
 import nz.eloque.foss_wallet.model.TransitType
+import nz.eloque.foss_wallet.model.field.PassField
 import nz.eloque.foss_wallet.utils.forEach
 import org.json.JSONArray
 import org.json.JSONObject

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/DateView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/DateView.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import nz.eloque.foss_wallet.R
-import nz.eloque.foss_wallet.utils.prettyPrint
+import nz.eloque.foss_wallet.utils.prettyDateTime
 import java.time.Instant
 
 @Composable
@@ -46,13 +46,13 @@ fun DateView(
         Column {
             if (start != 0L) {
                 Text(
-                    text = Instant.ofEpochSecond(start).prettyPrint(),
+                    text = Instant.ofEpochSecond(start).prettyDateTime(),
                     style = MaterialTheme.typography.bodySmall
                 )
             }
             if (end != 0L) {
                 Text(
-                    text = Instant.ofEpochSecond(end).prettyPrint(),
+                    text = Instant.ofEpochSecond(end).prettyDateTime(),
                     style = MaterialTheme.typography.bodySmall
                 )
             }

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/PassLabel.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/PassLabel.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import nz.eloque.foss_wallet.model.field.PassContent
 
 private val linkStyle = TextLinkStyles(
     style = SpanStyle(
@@ -33,7 +34,7 @@ private val linkStyle = TextLinkStyles(
 @Composable
 fun PassLabel(
     label: String,
-    content: String,
+    content: PassContent,
     modifier: Modifier = Modifier,
     colors: CardColors = CardDefaults.outlinedCardColors(),
 ) {
@@ -58,9 +59,10 @@ fun PassLabel(
                     )
                 }
                 SelectionContainer {
+                    val contentString = content.prettyPrint()
                     Text(
-                        text = if (content.isNotEmpty()) {
-                            AnnotatedString.fromHtml(content, linkStyle) } else { AnnotatedString("-") },
+                        text = if (contentString.isNotEmpty()) {
+                            AnnotatedString.fromHtml(contentString, linkStyle) } else { AnnotatedString("-") },
                         style = MaterialTheme.typography.bodyLarge
                     )
                 }
@@ -74,7 +76,7 @@ fun PassLabel(
 private fun PassLabelPreview() {
     PassLabel(
         label = "GRP",
-        content = "34"
+        content = PassContent.Plain("34")
     )
 }
 
@@ -83,7 +85,7 @@ private fun PassLabelPreview() {
 private fun LongPassLabelPreview() {
     PassLabel(
         label = "Information",
-        content = """
+        content = PassContent.Plain("""
             This is a long text.
             
             Possibly multiple lines
@@ -98,7 +100,7 @@ private fun LongPassLabelPreview() {
              wa dwa
              
              Lorem Ipsum
-        """.trimIndent()
+        """.trimIndent())
     )
 }
 
@@ -107,13 +109,13 @@ private fun LongPassLabelPreview() {
 private fun HtmlPassLabelPreview() {
     PassLabel(
         label = "Information",
-        content = """
+        content = PassContent.Plain("""
             <p>
             This is a paragraph
             </p>
             This should <b> bold. </b>
             <a href="https://example.com">This is a link</a>
              Lorem Ipsum
-        """.trimIndent()
+        """.trimIndent())
     )
 }

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/card_primary/AirlineBoardingPrimary.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/card_primary/AirlineBoardingPrimary.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import nz.eloque.foss_wallet.R
 import nz.eloque.foss_wallet.model.Pass
 import nz.eloque.foss_wallet.model.TransitType
+import nz.eloque.foss_wallet.model.field.PassContent
 import nz.eloque.foss_wallet.ui.components.AbbreviatingText
 import nz.eloque.foss_wallet.ui.components.pass_view.PassField
 import nz.eloque.foss_wallet.utils.darken
@@ -30,14 +31,14 @@ fun AirlineBoardingPrimary(
 
     if (pass.primaryFields.size == 1) {
         val field = pass.primaryFields[0]
-        PassField(field.label, field.value, cardColors = cardColors)
+        PassField(field.label, field.content, cardColors = cardColors)
     } else if (pass.primaryFields.size >= 2) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(10.dp)
         ) {
             DestinationCard(
-                destination = pass.primaryFields[0].value,
+                destination = pass.primaryFields[0].content,
                 modifier = Modifier.weight(2f),
                 cardColors
             )
@@ -47,7 +48,7 @@ fun AirlineBoardingPrimary(
                 modifier = Modifier.weight(1f)
             )
             DestinationCard(
-                destination = pass.primaryFields[1].value,
+                destination = pass.primaryFields[1].content,
                 modifier = Modifier.weight(2f),
                 cardColors
             )
@@ -57,7 +58,7 @@ fun AirlineBoardingPrimary(
 
 @Composable
 private fun DestinationCard(
-    destination: String,
+    destination: PassContent,
     modifier: Modifier = Modifier,
     cardColors: CardColors
 ) {
@@ -66,8 +67,8 @@ private fun DestinationCard(
         modifier = modifier
     ) {
         AbbreviatingText(
-            text = destination,
-            style = if (destination.length <= 3) { MaterialTheme.typography.headlineLarge } else { MaterialTheme.typography.headlineSmall },
+            text = destination.prettyPrint(),
+            style = if (destination.prettyPrint().length <= 3) { MaterialTheme.typography.headlineLarge } else { MaterialTheme.typography.headlineSmall },
             maxLines = 1,
             textAlign = TextAlign.Center,
             modifier = Modifier

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/card_primary/GenericBoardingPrimary.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/card_primary/GenericBoardingPrimary.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.unit.dp
 import nz.eloque.foss_wallet.R
 import nz.eloque.foss_wallet.model.Pass
 import nz.eloque.foss_wallet.model.TransitType
+import nz.eloque.foss_wallet.model.field.PassContent
 import nz.eloque.foss_wallet.ui.components.pass_view.PassField
 import nz.eloque.foss_wallet.utils.darken
 
@@ -25,7 +26,7 @@ fun GenericBoardingPrimary(
 ) {
     if (pass.primaryFields.size == 1) {
         val field = pass.primaryFields[0]
-        PassField(field.label, field.value, cardColors = cardColors)
+        PassField(field.label, field.content, cardColors = cardColors)
     } else if (pass.primaryFields.size >= 2) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -33,7 +34,7 @@ fun GenericBoardingPrimary(
         ) {
             DestinationCard(
                 label = pass.primaryFields[0].label,
-                destination = pass.primaryFields[0].value,
+                destination = pass.primaryFields[0].content,
                 modifier = Modifier.weight(2f),
                 cardColors
             )
@@ -44,7 +45,7 @@ fun GenericBoardingPrimary(
             )
             DestinationCard(
                 label = pass.primaryFields[1].label,
-                destination = pass.primaryFields[1].value,
+                destination = pass.primaryFields[1].content,
                 modifier = Modifier.weight(2f),
                 cardColors
             )
@@ -55,7 +56,7 @@ fun GenericBoardingPrimary(
 @Composable
 private fun DestinationCard(
     label: String,
-    destination: String,
+    destination: PassContent,
     modifier: Modifier = Modifier,
     cardColors: CardColors
 ) {

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/pass_view/PassView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/pass_view/PassView.kt
@@ -87,20 +87,20 @@ private fun PassPreview() {
     ).also {
         it.relevantDate = 1800000000L
         it.headerFields = mutableListOf(
-            nz.eloque.foss_wallet.model.PassField("block", "Block", "S1"),
-            nz.eloque.foss_wallet.model.PassField("seat", "Seat", "47"),
+            nz.eloque.foss_wallet.model.field.PassField("block", "Block", "S1"),
+            nz.eloque.foss_wallet.model.field.PassField("seat", "Seat", "47"),
         )
         it.primaryFields = mutableListOf(
-            nz.eloque.foss_wallet.model.PassField("name", "Name", "Max Mustermann"),
-            nz.eloque.foss_wallet.model.PassField("seat", "Seat", "47"),
+            nz.eloque.foss_wallet.model.field.PassField("name", "Name", "Max Mustermann"),
+            nz.eloque.foss_wallet.model.field.PassField("seat", "Seat", "47"),
         )
         it.auxiliaryFields = mutableListOf(
-            nz.eloque.foss_wallet.model.PassField("block", "Block", "S1 | Gegengerade"),
-            nz.eloque.foss_wallet.model.PassField("seat", "Seat", "36E"),
+            nz.eloque.foss_wallet.model.field.PassField("block", "Block", "S1 | Gegengerade"),
+            nz.eloque.foss_wallet.model.field.PassField("seat", "Seat", "36E"),
         )
         it.secondaryFields = mutableListOf(
-            nz.eloque.foss_wallet.model.PassField("data1", "data1", "Longer Value here i guess"),
-            nz.eloque.foss_wallet.model.PassField("data2", "data2", "Shorter Value"),
+            nz.eloque.foss_wallet.model.field.PassField("data1", "data1", "Longer Value here i guess"),
+            nz.eloque.foss_wallet.model.field.PassField("data2", "data2", "Shorter Value"),
         )
     }
     PassView(pass, true)

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/pass_view/PassView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/pass_view/PassView.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import nz.eloque.foss_wallet.model.Pass
 import nz.eloque.foss_wallet.model.PassType
+import nz.eloque.foss_wallet.model.field.PassContent
 import nz.eloque.foss_wallet.ui.components.PassCard
 import java.time.Instant
 
@@ -87,20 +88,20 @@ private fun PassPreview() {
     ).also {
         it.relevantDate = 1800000000L
         it.headerFields = mutableListOf(
-            nz.eloque.foss_wallet.model.field.PassField("block", "Block", "S1"),
-            nz.eloque.foss_wallet.model.field.PassField("seat", "Seat", "47"),
+            nz.eloque.foss_wallet.model.field.PassField("block", "Block", PassContent.Plain("S1")),
+            nz.eloque.foss_wallet.model.field.PassField("seat", "Seat", PassContent.Plain("47")),
         )
         it.primaryFields = mutableListOf(
-            nz.eloque.foss_wallet.model.field.PassField("name", "Name", "Max Mustermann"),
-            nz.eloque.foss_wallet.model.field.PassField("seat", "Seat", "47"),
+            nz.eloque.foss_wallet.model.field.PassField("name", "Name", PassContent.Plain("Max Mustermann")),
+            nz.eloque.foss_wallet.model.field.PassField("seat", "Seat", PassContent.Plain("47")),
         )
         it.auxiliaryFields = mutableListOf(
-            nz.eloque.foss_wallet.model.field.PassField("block", "Block", "S1 | Gegengerade"),
-            nz.eloque.foss_wallet.model.field.PassField("seat", "Seat", "36E"),
+            nz.eloque.foss_wallet.model.field.PassField("block", "Block", PassContent.Plain("S1 | Gegengerade")),
+            nz.eloque.foss_wallet.model.field.PassField("seat", "Seat", PassContent.Plain("36E")),
         )
         it.secondaryFields = mutableListOf(
-            nz.eloque.foss_wallet.model.field.PassField("data1", "data1", "Longer Value here i guess"),
-            nz.eloque.foss_wallet.model.field.PassField("data2", "data2", "Shorter Value"),
+            nz.eloque.foss_wallet.model.field.PassField("data1", "data1", PassContent.Plain("Longer Value here i guess")),
+            nz.eloque.foss_wallet.model.field.PassField("data2", "data2", PassContent.Plain("Shorter Value")),
         )
     }
     PassView(pass, true)

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/pass_view/PassViewComponents.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/pass_view/PassViewComponents.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import nz.eloque.foss_wallet.R
 import nz.eloque.foss_wallet.model.BarCode
-import nz.eloque.foss_wallet.model.PassField
+import nz.eloque.foss_wallet.model.field.PassField
 import nz.eloque.foss_wallet.ui.components.PassLabel
 import nz.eloque.foss_wallet.ui.components.Raise
 import nz.eloque.foss_wallet.ui.components.UpdateBrightness

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/pass_view/PassViewComponents.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/pass_view/PassViewComponents.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import nz.eloque.foss_wallet.R
 import nz.eloque.foss_wallet.model.BarCode
+import nz.eloque.foss_wallet.model.field.PassContent
 import nz.eloque.foss_wallet.model.field.PassField
 import nz.eloque.foss_wallet.ui.components.PassLabel
 import nz.eloque.foss_wallet.ui.components.Raise
@@ -42,7 +43,7 @@ fun HeaderFieldsView(
         for (field in headerFields) {
             PassLabel(
                 label = field.label,
-                content = field.value,
+                content = field.content,
                 colors = cardColors,
                 modifier = Modifier.weight(1f)
             )
@@ -115,7 +116,7 @@ fun AsyncPassImage(
 @Composable
 fun PassField(
     label: String,
-    value: String,
+    value: PassContent,
     modifier: Modifier = Modifier,
     cardColors: CardColors = CardDefaults.outlinedCardColors()
 ) {
@@ -138,7 +139,7 @@ fun PassFields(
         modifier = modifier
     ) {
         fields.forEach {
-            PassField(it.label, it.value, Modifier.fillMaxWidth(), cardColors)
+            PassField(it.label, it.content, Modifier.fillMaxWidth(), cardColors)
         }
     }
 }

--- a/app/src/main/java/nz/eloque/foss_wallet/utils/ExtensionFunctions.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/utils/ExtensionFunctions.kt
@@ -27,9 +27,21 @@ fun JSONArray.forEach(action: (JSONObject) -> Unit) {
     }
 }
 
-fun Instant.prettyPrint(): String {
+fun Instant.prettyDateTime(style: FormatStyle = FormatStyle.SHORT): String {
     val zonedTime = ZonedDateTime.ofInstant(this, ZoneId.systemDefault())
-    val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
+    val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedDateTime(style)
+    return zonedTime.format(dateFormatter)
+}
+
+fun Instant.prettyDate(style: FormatStyle = FormatStyle.SHORT): String {
+    val zonedTime = ZonedDateTime.ofInstant(this, ZoneId.systemDefault())
+    val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedDate(style)
+    return zonedTime.format(dateFormatter)
+}
+
+fun Instant.prettyTime(style: FormatStyle = FormatStyle.SHORT): String {
+    val zonedTime = ZonedDateTime.ofInstant(this, ZoneId.systemDefault())
+    val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedTime(style)
     return zonedTime.format(dateFormatter)
 }
 


### PR DESCRIPTION
This PR enables date rendering in Pass Fields.

Furthermore, due to the refactoring of the data model, currency can also be rendered correctly now.