### PR TITLE
Fix display of passes without logo file

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/card/PassRows.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/card/PassRows.kt
@@ -1,6 +1,7 @@
 package nz.eloque.foss_wallet.ui.card
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -33,13 +34,19 @@ fun HeaderRow(
         modifier = Modifier.fillMaxWidth()
             .padding(12.dp)
     ) {
-        AsyncImage(
-            model = pass.logoFile(context),
-            contentDescription = stringResource(R.string.image),
-            contentScale = ContentScale.FillHeight,
-            modifier = Modifier.padding(5.dp)
+        if (pass.hasLogo)
+            AsyncImage(
+                model = pass.logoFile(context),
+                contentDescription = stringResource(R.string.image),
+                contentScale = ContentScale.FillHeight,
+                modifier = Modifier.padding(5.dp)
+                    .height(28.dp)
+            )
+        else
+            Box(
+                modifier = Modifier.padding(5.dp)
                 .height(28.dp)
-        )
+            )
         pass.logoText?.let {
             AbbreviatingText(
                 text = pass.logoText!!,

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/card/PassRows.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/card/PassRows.kt
@@ -1,7 +1,6 @@
 package nz.eloque.foss_wallet.ui.card
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -22,6 +21,7 @@ import nz.eloque.foss_wallet.ui.components.AbbreviatingText
 import nz.eloque.foss_wallet.ui.components.DateView
 import nz.eloque.foss_wallet.ui.components.LocationButton
 import nz.eloque.foss_wallet.ui.view.pass.HeaderFieldsView
+import java.io.File
 
 @Composable
 fun HeaderRow(
@@ -34,31 +34,42 @@ fun HeaderRow(
         modifier = Modifier.fillMaxWidth()
             .padding(12.dp)
     ) {
-        if (pass.hasLogo)
-            AsyncImage(
-                model = pass.logoFile(context),
-                contentDescription = stringResource(R.string.image),
-                contentScale = ContentScale.FillHeight,
-                modifier = Modifier.padding(5.dp)
-                    .height(28.dp)
-            )
-        else
-            Box(
-                modifier = Modifier.padding(5.dp)
+        LogoView(
+            pass.logoFile(context),
+            pass.logoText,
+            Modifier.weight(1f)
+        )
+
+        HeaderFieldsView(
+            headerFields = pass.headerFields
+        )
+    }
+}
+
+@Composable
+private fun LogoView(
+    logoFile: File?,
+    logoText: String?,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+    ) {
+        logoFile?.let { AsyncImage(
+            model = it,
+            contentDescription = stringResource(R.string.image),
+            contentScale = ContentScale.FillHeight,
+            modifier = Modifier.padding(5.dp)
                 .height(28.dp)
-            )
-        pass.logoText?.let {
+        ) }
+        logoText?.let {
             AbbreviatingText(
-                text = pass.logoText!!,
+                text = it,
                 maxLines = 1,
                 style = MaterialTheme.typography.headlineMedium,
                 modifier = Modifier.weight(1f)
             )
         }
-
-        HeaderFieldsView(
-            headerFields = pass.headerFields
-        )
     }
 }
 

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/view/pass/PassViewComponents.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/view/pass/PassViewComponents.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -40,11 +41,15 @@ import java.io.File
 fun HeaderFieldsView(
     headerFields: List<PassField>
 ) {
-    headerFields.forEach { PlainPassLabel(
-        label = it.label,
-        content = it.content,
-        labelAlign = LabelAlign.RIGHT,
-    ) }
+    Row(
+        modifier = Modifier.wrapContentWidth(Alignment.End)
+    ) {
+        headerFields.forEach { PlainPassLabel(
+            label = it.label,
+            content = it.content,
+            labelAlign = LabelAlign.RIGHT,
+        ) }
+    }
 }
 
 @Composable


### PR DESCRIPTION
When a pass doesn't have a logo file the space used for the logo gets too wide, leaving only a single character for the rest of the data to be displayed. Replace it with an empty box if no logo is present so the layout is as expected.

Fixes #112.