### PR TITLE
Use charset specified in pkpass file

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/parsing/PassParser.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/parsing/PassParser.kt
@@ -18,6 +18,7 @@ import nz.eloque.foss_wallet.utils.Hash
 import nz.eloque.foss_wallet.utils.forEach
 import org.json.JSONException
 import org.json.JSONObject
+import java.nio.charset.Charset
 import java.time.Instant
 import java.time.ZonedDateTime
 import java.time.format.DateTimeParseException
@@ -150,7 +151,12 @@ class PassParser(val context: Context? = null) {
             null
         } else {
             val barcodeFormat = BarCode.formatFromString(barcodeFormatString)
-            BarCode(barcodeFormat, barcodeJSON.getString("message"), barcodeJSON.stringOrNull("altText"))
+            BarCode(
+                barcodeFormat,
+                barcodeJSON.getString("message"),
+                Charset.forName(barcodeJSON.optString("messageEncoding", BarCode.FALLBACK_CHARSET.toString())),
+                barcodeJSON.stringOrNull("altText")
+            )
         }
     }
 


### PR DESCRIPTION
Previously we used the default charset, which fails for cyrillic characters e.g.. With these changes we utilize the encoding specified in the pass, and only fall back to UTF-8 if we do not support it.