### PR TITLE
Show strip picture if primaryFields is empty

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/card/PassContent.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/card/PassContent.kt
@@ -23,6 +23,7 @@ fun ShortPassContent(
     cardColors: CardColors,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
     Column(
         verticalArrangement = Arrangement.spacedBy(6.dp),
         modifier = modifier
@@ -37,6 +38,8 @@ fun ShortPassContent(
                 }
             else -> GenericPrimary(pass)
         }
+        if (pass.primaryFields.isEmpty() && pass.hasStrip)
+            AsyncPassImage(model = pass.stripFile(context), modifier = Modifier.fillMaxWidth())
 
         DateLocationRow(pass)
     }

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/card/PassContent.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/card/PassContent.kt
@@ -38,8 +38,9 @@ fun ShortPassContent(
                 }
             else -> GenericPrimary(pass)
         }
-        if (pass.primaryFields.isEmpty() && pass.hasStrip)
+        if (pass.primaryFields.isEmpty() && pass.hasStrip) {
             AsyncPassImage(model = pass.stripFile(context), modifier = Modifier.fillMaxWidth())
+        }
 
         DateLocationRow(pass)
     }


### PR DESCRIPTION
Some passes have an empty primaryFields but a strip picture containing the relevant information. In this case show the strip in the short content to avoid those passes showing up as (almost) empty cards.

Fixes #117