### PR TITLE
Improve error messages and details handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,12 @@ plugins {
     alias(libs.plugins.hilt.android)
 }
 
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xwhen-guards")
+    }
+}
+
 android {
     dependenciesInfo {
         // Disables dependency metadata when building APKs.

--- a/app/src/main/java/nz/eloque/foss_wallet/api/PassbookApi.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/api/PassbookApi.kt
@@ -40,7 +40,11 @@ object PassbookApi {
                 return UpdateResult.Failed(FailureReason.Exception(e))
             }
         } else {
-            return UpdateResult.Failed(FailureReason.Status(response.code))
+            return when (response.code) {
+                304 -> UpdateResult.NotUpdated
+                403 -> UpdateResult.Failed(FailureReason.Forbidden)
+                else -> UpdateResult.Failed(FailureReason.Status(response.code))
+            }
         }
     }
 

--- a/app/src/main/java/nz/eloque/foss_wallet/api/UpdateResult.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/api/UpdateResult.kt
@@ -6,6 +6,7 @@ import nz.eloque.foss_wallet.persistence.PassLoadResult
 
 sealed class UpdateResult() {
     data class Success(val content: UpdateContent) : UpdateResult()
+    data object NotUpdated : UpdateResult()
     data class Failed(val reason: FailureReason) : UpdateResult()
 }
 
@@ -14,8 +15,10 @@ sealed class UpdateContent() {
     data class Pass(val pass: nz.eloque.foss_wallet.model.Pass) : UpdateContent()
 }
 
-sealed class FailureReason(@StringRes val messageId: Int, val detailed: Boolean) {
-    object Timeout : FailureReason(R.string.timeout, false)
-    data class Exception(val exception: kotlin.Exception) : FailureReason(R.string.exception, true)
-    data class Status(val status: Int) : FailureReason(R.string.status_code, false)
+sealed class FailureReason(@StringRes val messageId: Int) {
+    object Timeout : FailureReason(R.string.timeout)
+    data class Exception(val exception: kotlin.Exception) : FailureReason(R.string.exception), Detailed
+    data class Status(val status: Int) : FailureReason(R.string.status_code), Detailed
+    data object Forbidden : FailureReason(R.string.status_forbidden)
+    interface Detailed
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -43,4 +43,6 @@
     <string name="exception">Es ist ein Fehler bei der Verbindung zum Server aufgetreten</string>
     <string name="status_code">Der Server hat mit Status %1$s geantwortet</string>
     <string name="copy">Kopieren</string>
+    <string name="status_forbidden">Der Server hat den Zugriff auf den Pass verwehrt. Ist der Pass vielleicht schon abgelaufen?</string>
+    <string name="status_not_updated">Der Pass ist bereits aktuell</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,4 +44,6 @@
     <string name="exception">An Exception occurred while calling the update server</string>
     <string name="copy">Copy</string>
     <string name="status_code">The server replied with status %1$s</string>
+    <string name="status_forbidden">The server did not allow access to the pass. Maybe this pass is already expired?</string>
+    <string name="status_not_updated">Your Pass is already up-to-date</string>
 </resources>


### PR DESCRIPTION
This PR improves some standard error reasons that might occur when updating a pass and also links to the mozilla developer documentation for status codes not explicitly handled in the app.