### PR TITLE
Different icon for license

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/view/about/AboutView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/view/about/AboutView.kt
@@ -68,7 +68,7 @@ fun AboutView() {
             uri = "https://github.com/SeineEloquenz/fosswallet"
         )
         UriButton(
-            icon = Icons.Default.Description,
+            icon = Icons.Default.Balance,
             text = stringResource(R.string.license),
             uri = "https://github.com/SeineEloquenz/fosswallet/blob/main/LICENSE"
         )

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/view/about/AboutView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/view/about/AboutView.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Construction
-import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Balance
 import androidx.compose.material.icons.filled.PrivacyTip
 import androidx.compose.material.icons.filled.Source
 import androidx.compose.material.icons.filled.Wallet


### PR DESCRIPTION
Better distinguishable icons, as the icons for source code and license look too similar. The scale is also used by GitHub as an icon for license.