### PR TITLE
Allow intents to work with .pkpass files with different MIME types

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,10 +28,38 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content"/>
+                <data android:mimeType="application/pkpass"/>
+                <data android:scheme="file"/>
+                <data android:mimeType="application/pkpass"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="content"/>
                 <data android:mimeType="application/vnd.apple.pkpass"/>
                 <data android:scheme="file"/>
                 <data android:mimeType="application/vnd.apple.pkpass"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content"/>
+                <data android:mimeType="application/vnd-com.apple.pkpass"/>
+                <data android:scheme="file"/>
+                <data android:mimeType="application/vnd-com.apple.pkpass"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content"/>
+                <data android:mimeType="application/octet-stream"/>
+                <data android:scheme="file"/>
+                <data android:mimeType="application/octet-stream"/>
             </intent-filter>
 
             <intent-filter>


### PR DESCRIPTION
A downloaded `.pkpass` might not always say it's a `.pkpass`. Other apps handle this: for example, PassWallet covers the following MIME types, which I've mostly added to FossWallet too:

- `application/pkpass`
- `application/vnd.apple.pkpass`
- `application/vnd-com.apple.pkpass`
- `application/zip` (I did not add this one)
- `application/octet-stream`

The most useful one is `application/octet-stream` - this covers many files that aren't necessary calling themselves a `.pkpass`. Importantly, it also allows intents to work on Android 14! On Android 14, opening a `.pkpass` file doesn't currently trigger the intent for FossWallet - you have to manually import it from the app, which is a bit annoying.

I decided against including `application/zip`, as this could trigger random zips, but honestly I don't think it's really a problem - the first option when clicking a zip is for the app you're in to offer to unzip it. And again - other Wallet apps (PassWallet, Google Wallet) do include it, so if you want to, I can add it in too.

If the file being opened isn't a valid `.pkpass`, the usual error toast shows up anyway.