### PR TITLE
Show a toast when trying to add a pre-existing pass

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/MainActivity.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/MainActivity.kt
@@ -85,7 +85,7 @@ class MainActivity : ComponentActivity() {
                             is ImportResult.New -> navController.navigate("pass/$id")
                             is ImportResult.Replaced -> {
                                 Toast
-                                    .makeText(this@MainActivity, "Pass already imported", Toast.LENGTH_SHORT)
+                                    .makeText(this@MainActivity, this@MainActivity.getString(R.string.pass_already_imported), Toast.LENGTH_SHORT)
                                     .show()
                                 navController.navigate("pass/$id")
                             }

--- a/app/src/main/java/nz/eloque/foss_wallet/MainActivity.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/MainActivity.kt
@@ -21,6 +21,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import nz.eloque.foss_wallet.api.ImportResult
 import nz.eloque.foss_wallet.parsing.PassParser
 import nz.eloque.foss_wallet.persistence.InvalidPassException
 import nz.eloque.foss_wallet.persistence.PassLoader
@@ -77,10 +78,19 @@ class MainActivity : ComponentActivity() {
             it?.let {
                 try {
                     val loadResult = PassLoader(PassParser(this@MainActivity)).load(it)
-                    passViewModel.add(loadResult)
+                    val importResult = passViewModel.add(loadResult)
                     val id: String = loadResult.pass.pass.id
-                    coroutineScope.launch(Dispatchers.Main) { navController
-                        .navigate("pass/$id") }
+                    coroutineScope.launch(Dispatchers.Main) {
+                        when (importResult) {
+                            is ImportResult.New -> navController.navigate("pass/$id")
+                            is ImportResult.Replaced -> {
+                                Toast
+                                    .makeText(this@MainActivity, "Pass already imported", Toast.LENGTH_SHORT)
+                                    .show()
+                                navController.navigate("pass/$id")
+                            }
+                        }
+                    }
                 } catch (e: InvalidPassException) {
                     Log.w(TAG, "Failed to load pass from intent: $e")
                     coroutineScope.launch(Dispatchers.Main) { Toast

--- a/app/src/main/java/nz/eloque/foss_wallet/api/ImportResult.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/api/ImportResult.kt
@@ -1,0 +1,6 @@
+package nz.eloque.foss_wallet.api
+
+sealed class ImportResult {
+    object New : ImportResult()
+    object Replaced : ImportResult()
+}

--- a/app/src/main/java/nz/eloque/foss_wallet/persistence/pass/PassDao.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/persistence/pass/PassDao.kt
@@ -24,6 +24,10 @@ interface PassDao {
     @Query("SELECT * FROM pass WHERE id=:id")
     fun byId(id: String): PassWithLocalization
 
+    @Transaction
+    @Query("SELECT * FROM pass WHERE id=:id")
+    fun findById(id: String): PassWithLocalization?
+
     @Query("UPDATE pass SET groupId = :groupId WHERE id = :passId")
     fun associate(passId: String, groupId: Long)
 

--- a/app/src/main/java/nz/eloque/foss_wallet/persistence/pass/PassRepository.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/persistence/pass/PassRepository.kt
@@ -30,6 +30,8 @@ class PassRepository @Inject constructor(
 
     fun byId(id: String): PassWithLocalization = passDao.byId(id)
 
+    fun findById(id: String): PassWithLocalization? = passDao.findById(id)
+
     fun associate(pass: Pass, group: PassGroup) = passDao.associate(pass.id, group.id)
 
     fun insert(pass: Pass, bitmaps: PassBitmaps, originalPass: OriginalPass) {

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/WalletScreen.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/WalletScreen.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import nz.eloque.foss_wallet.R
+import nz.eloque.foss_wallet.api.ImportResult
 import nz.eloque.foss_wallet.model.Pass
 import nz.eloque.foss_wallet.persistence.InvalidPassException
 import nz.eloque.foss_wallet.ui.Screen
@@ -56,7 +57,17 @@ fun WalletScreen(
             coroutineScope.launch(Dispatchers.IO) {
                 contentResolver.openInputStream(res)?.use { inputStream ->
                     try {
-                        passViewModel.load(context, inputStream)
+                        val importResult = passViewModel.load(context, inputStream)
+                        withContext(Dispatchers.Main) {
+                            when (importResult) {
+                                is ImportResult.New -> {
+                                    // Pass imported successfully
+                                }
+                                is ImportResult.Replaced -> {
+                                    Toast.makeText(context, "Pass already imported", Toast.LENGTH_SHORT).show()
+                                }
+                            }
+                        }
                     } catch (_: InvalidPassException) {
                         withContext(Dispatchers.Main) {
                             Toast.makeText(context, toastMessage, Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/WalletScreen.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/WalletScreen.kt
@@ -64,7 +64,7 @@ fun WalletScreen(
                                     // Pass imported successfully
                                 }
                                 is ImportResult.Replaced -> {
-                                    Toast.makeText(context, "Pass already imported", Toast.LENGTH_SHORT).show()
+                                    Toast.makeText(context, context.getString(R.string.pass_already_imported), Toast.LENGTH_SHORT).show()
                                 }
                             }
                         }

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/view/wallet/WalletViewModel.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/view/wallet/WalletViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import nz.eloque.foss_wallet.api.ImportResult
 import nz.eloque.foss_wallet.api.UpdateResult
 import nz.eloque.foss_wallet.model.Pass
 import nz.eloque.foss_wallet.model.PassWithLocalization
@@ -71,13 +72,13 @@ class PassViewModel @Inject constructor(
         }
     }
 
-    fun add(loadResult: PassLoadResult) = passStore.add(loadResult).apply { updatePasses() }
+    fun add(loadResult: PassLoadResult): ImportResult = passStore.add(loadResult).apply { updatePasses() }
 
     suspend fun update(pass: Pass): UpdateResult = passStore.update(pass).apply { updatePasses() }
 
     fun delete(pass: Pass) = passStore.delete(pass).apply { updatePasses() }
 
-    fun load(context: Context, inputStream: InputStream) = passStore.load(context, inputStream).apply { updatePasses() }
+    fun load(context: Context, inputStream: InputStream): ImportResult = passStore.load(context, inputStream).apply { updatePasses() }
     fun associate(groupId: Long, passes: Set<Pass>) = passStore.associate(groupId, passes).apply { updatePasses() }
     fun dessociate(pass: Pass, groupId: Long) = passStore.dessociate(pass, groupId).apply { updatePasses() }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,4 +52,5 @@
     <string name="pass_view_brightness">Increase Brightness</string>
     <string name="barcode_position_top">Top</string>
     <string name="barcode_position_center">Center</string>
+    <string name="pass_already_imported">Pass already imported</string>
 </resources>


### PR DESCRIPTION
Currently, if you add a pass that already exists in the db, nothing in the UI really happens.

This shows a toast that the pass already existed. Happens when coming from an intent, and when adding from the app itself.

Implements #210 