### PR TITLE
Simplify strings

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/view/settings/SettingsView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/view/settings/SettingsView.kt
@@ -37,7 +37,7 @@ fun SettingsView(
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         SettingsSection(
-            heading = stringResource(R.string.enable_sync),
+            heading = stringResource(R.string.pass_updates),
         ) {
             SettingsSwitch(
                 name = R.string.enable,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,8 +32,7 @@
     <string name="group">Group passes</string>
     <string name="ungroup">Ungroup passes</string>
     <string name="passes">Passes</string>
-    <string name="sync_interval">Pass update interval (min.)</string>
-    <string name="enable_sync">Pass updates</string>
+    <string name="sync_interval">Pass update interval (min)</string>
     <string name="enable">Enable</string>
     <string name="search">Search</string>
     <string name="add_shortcut">Add shortcut</string>


### PR DESCRIPTION
- enable_sync changed to pass_updates since both serve the same purpose (now)
- min. to min since the official SI unit for minutes is written without a dot