### PR TITLE
Better icon to clear text

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/FilterBar.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/FilterBar.kt
@@ -3,7 +3,7 @@ package nz.eloque.foss_wallet.ui.components
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Undo
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -56,7 +56,7 @@ fun FilterBar(
                                 onSearch.invoke("")
                             },
                         ) {
-                            Icon(imageVector = Icons.AutoMirrored.Default.Undo, contentDescription = stringResource(R.string.delete))
+                            Icon(imageVector = Icons.Default.Clear, contentDescription = stringResource(R.string.delete))
                         }
                     }
                 }


### PR DESCRIPTION
The bended arrow is normally used to undo the last text edit. The cross is more conventional.