### PR TITLE
Add support for RGBA colors

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/parsing/PassParser.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/parsing/PassParser.kt
@@ -176,10 +176,11 @@ class PassParser(val context: Context? = null) {
     private fun parseColor(key: String, passJson: JSONObject): Color? {
         return if (passJson.has(key)) {
             val representation = passJson.getString(key).filterNot { it.isWhitespace() }
-            val regexResult = "rgb\\((\\d+),(\\d+),(\\d+)\\)".toRegex().find((representation))
+            val regexResult = "rgba?\\((\\d+),(\\d+),(\\d+)(?:,([\\d.]+))?\\)".toRegex().find((representation))
             if (regexResult != null) {
-                val (red, green, blue) = regexResult.destructured
-                return Color(red.toInt(), green.toInt(), blue.toInt(), 255)
+                val (red, green, blue, alpha) = regexResult.destructured
+                val parsedAlpha = alpha.ifEmpty { "1.0" }.toDoubleOrNull() ?: return null
+                return Color(red.toInt(), green.toInt(), blue.toInt(), (parsedAlpha * 255.0).toInt())
             } else null
         } else null
     }


### PR DESCRIPTION
I had an airline boarding pass which was rendering with a white background and white text in images. I looked into the issue and found that the labelColor contained an RGBA value. This caused the current logic to fall back to the auto detected colors which in this case resulted in white text from the images on a white background. This PR solves this issue by adding support for RGBA values in any of the colors.