### PR TITLE
License note in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Prefer using builds from GitHub or F-Droid if possible.
 FossWallet can be translated via [Weblate](https://hosted.weblate.org/projects/fosswallet/app/).
 
 [![Translation status](https://hosted.weblate.org/widget/fosswallet/app/multi-auto.svg)](https://hosted.weblate.org/engage/fosswallet/)
+
+## License
+
+This project is licensed under the [GNU General Public License v3.0](LICENSE).


### PR DESCRIPTION
In accordance with this recommendation (https://www.gnu.org/licenses/gpl-faq.en.html#LicenseCopyOnly), a note regarding the license has been added to the README.