### PR TITLE
Add rounded box background to QR view

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/pass/PassViewComponents.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/pass/PassViewComponents.kt
@@ -2,6 +2,7 @@ package nz.eloque.foss_wallet.ui.screens.pass
 
 import android.graphics.Bitmap
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -16,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -27,6 +29,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
@@ -78,26 +82,34 @@ fun BarcodesView(
             .fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(5.dp))
+                .background(Color.White)
+                .padding(10.dp)
         ) {
-            Image(
-                bitmap = image.asImageBitmap(),
-                contentDescription = stringResource(R.string.image),
-                contentScale = ContentScale.Fit,
-                modifier = Modifier
-                    .heightIn(max = 150.dp)
-                    .widthIn(max = 150.dp)
-                    .clickable { fullscreen = !fullscreen }
-            )
-            barcode.altText?.let {
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = it,
-                    style = MaterialTheme.typography.labelSmall,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.width(180.dp)
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Image(
+                    bitmap = image.asImageBitmap(),
+                    contentDescription = stringResource(R.string.image),
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier
+                        .heightIn(max = 150.dp)
+                        .widthIn(max = 150.dp)
+                        .clickable { fullscreen = !fullscreen }
                 )
+                barcode.altText?.let {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = it,
+                        color = Color.Black,
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.width(150.dp)
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
Use a white box with rounded corners as background for the QR / barcode area, and put both the code and the alt text into it. This gives it a nicer look by being more in line with the general rounded corners, makes the code appear less "stamped" onto the pass, and improves alt text readability depending on the pass background color.

This also closer how Apple Wallet shows the barcode block.