### PR TITLE
Restore full strip width

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/card/PassContent.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/card/PassContent.kt
@@ -42,6 +42,7 @@ fun ShortPassContent(
         if (pass.primaryFields.empty() && pass.hasStrip) {
             AsyncPassImage(
                 model = pass.stripFile(context),
+                modifier = Modifier.fillMaxWidth()
             )
         }
 
@@ -78,6 +79,7 @@ fun PassContent(
         }
         AsyncPassImage(
             model = pass.stripFile(context),
+            modifier = Modifier.fillMaxWidth()
         )
         FieldsRow(pass.secondaryFields)
         FieldsRow(pass.auxiliaryFields)

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/pass/PassViewComponents.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/pass/PassViewComponents.kt
@@ -149,7 +149,7 @@ fun AsyncPassImage(
             AsyncImage(
                 model = it,
                 contentDescription = stringResource(R.string.image),
-                contentScale = ContentScale.Fit,
+                contentScale = ContentScale.FillWidth,
                 modifier = modifier
             )
         }


### PR DESCRIPTION
With the changes made in #310 the strip is now not expanded to the full pass width anymore if the underlying image is smaller than the pass width.

Restore the fillMaxWidth() modifier used on strip images, while keeping the height / width modifier removed. This will make portait strip images use the full width, resulting in a rather tall pass. In the case of DHL it also addresses the image still being to small in #322.