### PR TITLE
Reordering the items of 3-dot menu (PassScreen)

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/pass/PassScreen.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/pass/PassScreen.kt
@@ -106,6 +106,21 @@ fun Actions(
         IconButton(onClick = { expanded.value = !expanded.value }) {
             Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.more_options))
         }
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.add_shortcut)) },
+            leadingIcon =  {
+                Icon(imageVector = Icons.Default.AppShortcut, contentDescription = stringResource(R.string.add_shortcut))
+            },
+            onClick = {
+                Shortcut.create(context, pass, pass.description)
+            }
+        )
+        
+        val passFile = pass.originalPassFile(context)
+        if (passFile != null) {
+            PassShareButton(passFile)
+        }
+        
         DropdownMenu(
             expanded = expanded.value,
             onDismissRequest = { expanded.value = false }
@@ -145,19 +160,6 @@ fun Actions(
                     }
                 }
             }
-            val passFile = pass.originalPassFile(context)
-            if (passFile != null) {
-                PassShareButton(passFile)
-            }
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.add_shortcut)) },
-                leadingIcon =  {
-                    Icon(imageVector = Icons.Default.AppShortcut, contentDescription = stringResource(R.string.add_shortcut))
-                },
-                onClick = {
-                    Shortcut.create(context, pass, pass.description)
-                }
-            )
 
             DropdownMenuItem(
                 text = { Text(stringResource(R.string.delete), color = MaterialTheme.colorScheme.error) },


### PR DESCRIPTION
*Also here:* https://github.com/SeineEloquenz/fosswallet/pull/288

Since “Add Shortcut” (in the 3-dot menu of PassScreen) indicates that the pass is important, it would make sense not to display this option directly next to the delete option in the 3-dot menu in order to avoid “mistaken clicks.”
For the same reason, the share option has also been rearranged.