### PR TITLE
Fix change detection working on unlocalized old pass

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/api/UpdateWorker.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/api/UpdateWorker.kt
@@ -7,6 +7,7 @@ import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import nz.eloque.foss_wallet.persistence.PassStore
+import java.util.Locale
 
 @HiltWorker
 class UpdateWorker @AssistedInject constructor(
@@ -18,7 +19,7 @@ class UpdateWorker @AssistedInject constructor(
 
     override suspend fun doWork(): Result {
         val pass = passStore.passById(inputData.getString("id")!!)
-        val result = pass?.let { passStore.update(it.pass) }
+        val result = pass?.let { passStore.update(it.applyLocalization(Locale.getDefault().language)) }
         return if (result is UpdateResult.Success || result is UpdateResult.NotUpdated) {
             Result.success()
         } else {


### PR DESCRIPTION
The change detection compared unlocalized to localized passes. Therefore the change detection always noticed changes, leading to all available notifications being fired although there were no actual changes between two pass versions.