### PR TITLE
Add support for attributedValue in pass field

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/parsing/FieldParser.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/parsing/FieldParser.kt
@@ -11,7 +11,11 @@ object FieldParser {
     fun parse(field: JSONObject): PassField {
         val key = field.getString("key")
         val label = field.stringOrNull("label")
-        val value = field.getString("value")
+        val value = if (field.has("attributedValue")) {
+            field.getString("attributedValue")
+        } else {
+            field.getString("value")
+        }
         val changeMessage = if (field.has("changeMessage")) field.getString("changeMessage") else null
 
         val content = when {


### PR DESCRIPTION
The `attributedValue` property can contain html links and overwrites the content of the `value` key if it exists. This is used by some passes.

No further changes are required to display the links because `PassLabelContents()` already uses the `AnnotatedString.fromHtml()` function.