### PR TITLE
support importing multiple passes from webview

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletScreen.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletScreen.kt
@@ -39,6 +39,7 @@ import nz.eloque.foss_wallet.ui.WalletScaffold
 import java.net.URLEncoder
 import nz.eloque.foss_wallet.ui.components.FabMenu
 import nz.eloque.foss_wallet.ui.components.FabMenuItem
+import nz.eloque.foss_wallet.utils.PkpassMimeTypes
 
 @SuppressLint("LocalContextGetResourceValueCall")
 @OptIn(ExperimentalMaterial3Api::class)
@@ -151,15 +152,8 @@ fun WalletScreen(
                                 launcher.launch(arrayOf(
                                     "application/json+zip",
                                     "application/octet-stream",
-                                    "application/pkpass",
-                                    "application/pkpasses",
-                                    "application/vnd.apple.pkpass",
-                                    "application/vnd.apple.pkpasses",
-                                    "application/x-apple-pkpass",
-                                    "application/x-passbook",
-                                    "application/x-pkpass",
                                     "text/json"
-                                ))
+                                ).plus(PkpassMimeTypes))
                             }
                         )
                     )

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/webview/WebviewView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/webview/WebviewView.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.withContext
 import nz.eloque.foss_wallet.persistence.loader.Loader
 import nz.eloque.foss_wallet.persistence.loader.LoaderResult
 import nz.eloque.foss_wallet.ui.screens.wallet.PassViewModel
+import nz.eloque.foss_wallet.utils.PkpassMimeTypes
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -88,7 +89,7 @@ class CustomWebViewClient(
 
             val contentType = response.headers["content-type"]?.split(";")?.first()
 
-            if (contentType == "application/vnd.apple.pkpass") {
+            if(PkpassMimeTypes.contains(contentType)) {
                 return handlePkPassResponse(response)
             } else {
                 WebResourceResponse(contentType, "UTF-8", response.body.byteStream(), )
@@ -111,6 +112,10 @@ class CustomWebViewClient(
                     withContext(Dispatchers.Main) {
                         navController.popBackStack()
                         navController.navigate("pass/${result.passId}")
+                    }
+                } else if(result is LoaderResult.Multiple) {
+                    withContext(Dispatchers.Main) {
+                        navController.popBackStack()
                     }
                 }
             }

--- a/app/src/main/java/nz/eloque/foss_wallet/utils/MimeTypes.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/utils/MimeTypes.kt
@@ -1,0 +1,12 @@
+package nz.eloque.foss_wallet.utils
+
+
+val PkpassMimeTypes = arrayOf(
+    "application/pkpass",
+    "application/pkpasses",
+    "application/vnd.apple.pkpass",
+    "application/vnd.apple.pkpasses",
+    "application/x-apple-pkpass",
+    "application/x-passbook",
+    "application/x-pkpass",
+)


### PR DESCRIPTION
Moves the list of supported file types out so it can be accessed across the app and used for importing from webview

also handles navigation when multiple passes are imported from web