### PR TITLE
Trim trailing slash from web service urls

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/api/PassbookApi.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/api/PassbookApi.kt
@@ -18,7 +18,8 @@ object PassbookApi {
     private const val API_VERSION = "v1"
 
     suspend fun getUpdated(pass: Pass): UpdateResult {
-        val requestUrl = "${pass.webServiceUrl}/${API_VERSION}/passes/${pass.passTypeIdentifier}/${pass.serialNumber}"
+        val webServiceUrl = pass.webServiceUrl!!.trimEnd('/')
+        val requestUrl = "$webServiceUrl/${API_VERSION}/passes/${pass.passTypeIdentifier}/${pass.serialNumber}"
         val authHeader = Pair("Authorization", "ApplePass ${pass.authToken}")
 
         val client = OkHttpClient.Builder().build()


### PR DESCRIPTION
I found a pkpass where the web service url ended with a slash:

```json
"webServiceURL": "https://integration.oztix.com.au/applewallet/"
```

this resulted in the request url being formatted as `https://integration.oztix.com.au/applewallet//applewallet/v1/passes/` resulting in a 404 when trying to update. This fixes that