### PR TITLE
Fix wallet view filter ignoring non-generic boarding pass types

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/model/PassType.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/PassType.kt
@@ -7,15 +7,35 @@ import nz.eloque.foss_wallet.R
 sealed class PassType(val jsonKey: String, @param:StringRes val label:  Int) {
 
     @Entity
-    object Generic : PassType(GENERIC, R.string.generic_pass)
+    object Generic : PassType(GENERIC, R.string.generic_pass) {
+        override fun isSameType(passType: PassType): Boolean = this == passType
+    }
+
     @Entity
-    object Event: PassType(EVENT, R.string.event)
+    object Event: PassType(EVENT, R.string.event) {
+        override fun isSameType(passType: PassType): Boolean = this == passType
+    }
+
     @Entity
-    object Coupon : PassType(COUPON, R.string.coupon)
+    object Coupon : PassType(COUPON, R.string.coupon) {
+        override fun isSameType(passType: PassType): Boolean = this == passType
+    }
+
     @Entity
-    data class Boarding(val transitType: TransitType) : PassType(BOARDING, R.string.boarding_pass)
+    data class Boarding(val transitType: TransitType) : PassType(BOARDING, R.string.boarding_pass) {
+        override fun isSameType(passType: PassType): Boolean = this.javaClass == passType.javaClass
+    }
+
     @Entity
-    object StoreCard : PassType(STORE_CARD, R.string.store_card)
+    object StoreCard : PassType(STORE_CARD, R.string.store_card) {
+        override fun isSameType(passType: PassType) = this == passType
+    }
+
+    /**
+     * Checks whether two {@link PassType}s are the same type, regardless of possible further inner differentiation
+     * like flight or trains boarding pass
+     */
+    abstract fun isSameType(passType: PassType): Boolean
 
     companion object {
 

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletView.kt
@@ -128,7 +128,7 @@ fun WalletView(
                 }
             }
             val sortedPasses = passes
-                .filter { passTypesToShow.contains(it.type) }
+                .filter { pass -> passTypesToShow.any { pass.type.isSameType(it) } }
                 .sortedWith(sortOption.value.comparator)
                 .groupBy { it.groupId }.toList()
             val groups = sortedPasses.filter { it.first != null }

--- a/app/src/test/java/nz/eloque/foss_wallet/model/PassTypeTest.kt
+++ b/app/src/test/java/nz/eloque/foss_wallet/model/PassTypeTest.kt
@@ -1,0 +1,18 @@
+package nz.eloque.foss_wallet.model
+
+import org.junit.Test
+
+class PassTypeTest {
+
+    @Test
+    fun testIsSameType() {
+        val allPassTypes = PassType.all()
+        for (pass in allPassTypes) {
+            assert(allPassTypes.any { pass.isSameType(it) })
+        }
+        val boardingPassTypes = TransitType.entries.map { PassType.Boarding(it) }
+        for (pass in boardingPassTypes) {
+            assert(allPassTypes.any { pass.isSameType(it) })
+        }
+    }
+}


### PR DESCRIPTION
The contains filter only matches if a boarding pass has type GENERIC, which of course does not make sense. Therefore, a new checking method is introduced to ignore such lesser differentiation for filtering purposes