### PR TITLE
Fix barcode format when importing a pass

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/model/BarCode.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/BarCode.kt
@@ -92,7 +92,7 @@ data class BarCode(
 
         fun fromJson(json: JSONObject): BarCode {
             return BarCode(
-                formatFromString(json.getString("format")),
+                BarcodeFormat.valueOf(json.getString("format")),
                 json.getString("message"),
                 Charset.forName(json.optString("messageEncoding", FALLBACK_CHARSET.toString())),
                 if (json.has("altText")) { json.getString("altText") } else { null }
@@ -100,10 +100,11 @@ data class BarCode(
         }
 
         fun formatFromString(format: String): BarcodeFormat {
-            return try {
-                BarcodeFormat.valueOf(format)
-            } catch (_: IllegalArgumentException) {
-                BarcodeFormat.QR_CODE
+            return when (format) {
+                "PKBarcodeFormatPDF417" -> BarcodeFormat.PDF_417
+                "PKBarcodeFormatAztec" -> BarcodeFormat.AZTEC
+                "PKBarcodeFormatCode128" -> BarcodeFormat.CODE_128
+                else -> BarcodeFormat.QR_CODE
             }
         }
     }


### PR DESCRIPTION
This fixes a regression introduced by commit [9e1d2fa](https://github.com/SeineEloquenz/fosswallet/commit/9e1d2fa03b8d22db25edc883319dfb8734566ba3) that removed the mapping of the barcode format to the `BarcodeFormat` enum in the zxing package which is needed when importing a new pass. I used the strings according to the official pkpass documentation. The json format key in our own database is always a valid `BarcodeFormat` in string representation. Therefore no fallback format is necessary.

I would also suggest to remove the fallback to the qr code format in `formatFromString` and instead throw an exception because this would result in a misrepresented barcode and apple officially support only the four formats anyways.