### PR TITLE
Improve quick settings tile

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -139,6 +139,8 @@
         <service
             android:name=".quick_settings.WalletTileService"
             android:exported="true"
+            android:label="@string/app_name"
+            android:icon="@drawable/qs_icon"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
 
             <intent-filter>

--- a/app/src/main/java/nz/eloque/foss_wallet/quick_settings/WalletTileService.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/quick_settings/WalletTileService.kt
@@ -3,28 +3,27 @@ package nz.eloque.foss_wallet.quick_settings
 import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.content.Intent
-import android.graphics.drawable.Icon
 import android.os.Build
-import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import nz.eloque.foss_wallet.MainActivity
 import nz.eloque.foss_wallet.R
 
 class WalletTileService : TileService() {
 
-    override fun onStartListening() {
+    override fun onTileAdded() {
+        super.onTileAdded()
+
         qsTile.apply {
-            label = this@WalletTileService.getString(R.string.app_name)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                subtitle = this@WalletTileService.getString(R.string.open)
+                subtitle = getString(R.string.open)
             }
-            icon = Icon.createWithResource(this@WalletTileService, R.drawable.qs_icon)
-            state = Tile.STATE_INACTIVE
             updateTile()
         }
     }
 
     override fun onClick() {
+        super.onClick()
+
         val intent = Intent(this, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
             putExtra("from_tile", true)


### PR DESCRIPTION
Set the label and icon of the quick settings tile in the AndroidManifest instead of the TileService.

`onTileAdded()` is called once when the user adds the tile to the quick settings.

Fixes #433