### PR TITLE
WIP: Enable to sort by publisher

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/model/SortOption.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/SortOption.kt
@@ -5,13 +5,15 @@ import androidx.compose.runtime.saveable.Saver
 import nz.eloque.foss_wallet.R
 import java.time.ZonedDateTime
 
+
 const val TIME_ADDED = "TimeAdded"
+const val PUBLISHER = "Publisher"
 const val RELEVANT_DATE_NEWEST = "RelevantDateNewest"
 const val RELEVANT_DATE_OLDEST = "RelevantDateOldest"
 
-private val oldestFirst = Comparator.comparing<LocalizedPassWithTags, ZonedDateTime?>(
-    { it.pass.relevantDates.firstOrNull()?.startDate() },
-    Comparator.nullsLast(Comparator.naturalOrder())
+private val publisher = Comparator.comparing<LocalizedPassWithTags, String>(
+    { it.pass.organization.ifEmpty{it.pass.logoText?:""}.lowercase() },
+    Comparator.naturalOrder()
 )
 
 private val newestFirst = Comparator.comparing<LocalizedPassWithTags, ZonedDateTime?>(
@@ -19,17 +21,22 @@ private val newestFirst = Comparator.comparing<LocalizedPassWithTags, ZonedDateT
     Comparator.nullsLast(Comparator.reverseOrder())
 )
 
+private val oldestFirst = Comparator.comparing<LocalizedPassWithTags, ZonedDateTime?>(
+    { it.pass.relevantDates.firstOrNull()?.startDate() },
+    Comparator.nullsLast(Comparator.naturalOrder())
+)
 
 sealed class SortOption(val name: String, @param:StringRes val l18n: Int, val comparator: Comparator<LocalizedPassWithTags>) {
     object TimeAdded : SortOption(TIME_ADDED, R.string.date_added, Comparator { left, right ->
         -left.pass.addedAt.compareTo(right.pass.addedAt)
     })
+    object Publisher : SortOption(PUBLISHER, R.string.publisher, publisher)
     object RelevantDateNewest : SortOption(RELEVANT_DATE_NEWEST, R.string.relevant_date_newest, newestFirst)
     object RelevantDateOldest : SortOption(RELEVANT_DATE_OLDEST, R.string.relevant_date_oldest, oldestFirst)
 
     companion object {
         fun all(): List<SortOption> {
-            return listOf(TimeAdded, RelevantDateNewest, RelevantDateOldest)
+            return listOf(TimeAdded, Publisher, RelevantDateNewest, RelevantDateOldest)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,4 +89,5 @@
     <string name="tag_label">Tag label</string>
     <string name="collapse">Collapse</string>
     <string name="expand">Expand</string>
+    <string name="publisher">Publisher</string>
 </resources>


### PR DESCRIPTION
The “organization” field is used as the publisher. If this is empty, the “logoText” field is used. Entries are sorted alphabetically.