### PR TITLE
Tolerate empty values in pass fields

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/parsing/FieldParser.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/parsing/FieldParser.kt
@@ -13,8 +13,10 @@ object FieldParser {
         val label = field.stringOrNull("label")
         val value = if (field.has("attributedValue")) {
             field.getString("attributedValue")
-        } else {
+        } else if (field.has("value")) {
             field.getString("value")
+        } else {
+            "-"
         }
         val changeMessage = if (field.has("changeMessage")) field.getString("changeMessage") else null
 


### PR DESCRIPTION
While this is not compliant to the standard, some vendors (looking at you SWISS) build passes with unset value fields.