### PR TITLE
Remove the alpha channel from the hex code text + monospaced font

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/tag/TagCreator.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/tag/TagCreator.kt
@@ -30,7 +30,7 @@ import com.github.skydoves.colorpicker.compose.rememberColorPickerController
 import nz.eloque.foss_wallet.R
 import nz.eloque.foss_wallet.model.Tag
 
-val INITIAL_ENVELOPE: ColorEnvelope = ColorEnvelope(Color.White, "ffffff", false)
+val INITIAL_ENVELOPE: ColorEnvelope = ColorEnvelope(Color.White, "ffffffff", false)
 
 @Composable
 fun TagCreator(


### PR DESCRIPTION
Since the alpha channel of the hex code is always `ff` under the color tile anyway, it makes sense to spruce up the hex code by shortening it by the alpha channel.
To prevent the text from jumping back and forth when sliding, monospaced text was set.

That still counts as one feature, right?