### PR TITLE
Use the plural form of "share pass" in the SettingsScreen

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/settings/SettingsView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/settings/SettingsView.kt
@@ -95,7 +95,7 @@ fun SettingsView(
             )
         }
         SettingsSection(
-            heading = stringResource(R.string.export) + " / " + stringResource(R.string.share),
+            heading = stringResource(R.string.export) + " / " + stringResource(R.string.share_passes),
         ) {
             SettingsButton(
                 title = stringResource(R.string.export) + " (.pkpasses)",


### PR DESCRIPTION
I should have used the plural form from the start, sorry.