### PR TITLE
Remove redundant parameter from the Scaffold API

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/WalletScaffold.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/WalletScaffold.kt
@@ -36,7 +36,6 @@ fun WalletScaffold(
     modifier: Modifier = Modifier,
     title: String = stringResource(R.string.wallet),
     toolWindow: Boolean = false,
-    showBack: Boolean = true,
     actions: @Composable RowScope.() -> Unit = {},
     floatingActionButton: @Composable () -> Unit = {},
     bottomBar: @Composable () -> Unit = {},
@@ -54,7 +53,7 @@ fun WalletScaffold(
                     maxLines = 1,
                 ) },
                 navigationIcon = {
-                    if (toolWindow && showBack) {
+                    if (toolWindow) {
                         IconButton(onClick = { navController.popBackStack() }) {
                             Icon(imageVector = Icons.AutoMirrored.Default.ArrowBack, contentDescription = stringResource(R.string.back))
                         }


### PR DESCRIPTION
`showBack` is not used anywhere else and has the same usage as `toolWindow`.