### PR TITLE
Fix time zone handling in pretty printing of dates

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/utils/ExtensionFunctions.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/utils/ExtensionFunctions.kt
@@ -15,6 +15,7 @@ import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
@@ -59,7 +60,7 @@ private fun ZonedDateTime.pretty(dateFormatter: DateTimeFormatter, ignoresTimezo
     return if (ignoresTimezone) {
         this.toLocalDateTime().format(dateFormatter)
     } else {
-        this.format(dateFormatter)
+        this.withZoneSameInstant(ZoneId.systemDefault()).format(dateFormatter)
     }
 }
 


### PR DESCRIPTION
This should fix #368 so that the app now displays dates that have neither `ignoresTimeZone` nor `isRelative` set to `true` (e.g. birthdays) correctly depending on the system's time zone.
