### PR TITLE
Remove double click event of ShortPassCard

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/card/PassCard.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/card/PassCard.kt
@@ -12,9 +12,7 @@ import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
@@ -23,10 +21,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import nz.eloque.foss_wallet.model.LocalizedPassWithTags
 import nz.eloque.foss_wallet.model.PassColors
 import nz.eloque.foss_wallet.model.Tag
-import nz.eloque.foss_wallet.persistence.BarcodePosition
-import nz.eloque.foss_wallet.ui.components.FullscreenBarcode
 import nz.eloque.foss_wallet.ui.components.SelectionIndicator
-import nz.eloque.foss_wallet.ui.effects.UpdateBrightness
 import nz.eloque.foss_wallet.utils.darken
 
 
@@ -38,13 +33,10 @@ fun ShortPassCard(
     onClick: () -> Unit = {},
     onLongClick: () -> Unit,
     selected: Boolean = false,
-    increaseBrightness: Boolean = false,
-    barcodePosition: BarcodePosition,
     toned: Boolean = false
 ) {
     val cardColors = passCardColors(pass.pass.colors, toned)
     val scale by animateFloatAsState(if (selected) 0.95f else 1f)
-    var showBarcode by remember { mutableStateOf(false) }
 
     Box(
         modifier = Modifier.fillMaxWidth()
@@ -56,8 +48,7 @@ fun ShortPassCard(
                 .scale(scale)
                 .combinedClickable(
                     onClick = onClick,
-                    onLongClick = onLongClick,
-                    onDoubleClick = { pass.pass.barCodes.firstOrNull()?.let { showBarcode = true}}
+                    onLongClick = onLongClick
                 )
         ) {
             ShortPassContent(
@@ -69,25 +60,6 @@ fun ShortPassCard(
         if (selected) {
             SelectionIndicator(Modifier.align(Alignment.TopEnd))
         }
-    }
-
-    pass.pass.barCodes.firstOrNull()?.let { barcode ->
-        val image = barcode.encodeAsBitmap(
-            if (barcode.is1d()) 3000 else 1000,
-            1000,
-            pass.pass.renderLegacy && barcode.hasLegacyRepresentation()
-        )
-
-
-        if (showBarcode && increaseBrightness) {
-            UpdateBrightness()
-        }
-        FullscreenBarcode(
-            image = image,
-            barcodePosition = barcodePosition,
-            isFullscreen = showBarcode,
-            onDismiss = { showBarcode = !showBarcode },
-        )
     }
 }
 

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/GroupCard.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/GroupCard.kt
@@ -99,9 +99,7 @@ fun GroupCard(
                         }
                     },
                     selected = selectedPasses.contains(item),
-                    toned = true,
-                    barcodePosition = walletViewModel.barcodePosition(),
-                    increaseBrightness = walletViewModel.increasePassViewBrightness()
+                    toned = true
                 )
             }
             Box(

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletView.kt
@@ -193,9 +193,7 @@ fun WalletView(
                     onLongClick = {
                         if (selectedPasses.contains(pass)) selectedPasses.remove(pass) else selectedPasses.add(pass)
                     },
-                    selected = selectedPasses.contains(pass),
-                    barcodePosition = walletViewModel.barcodePosition(),
-                    increaseBrightness = walletViewModel.increasePassViewBrightness()
+                    selected = selectedPasses.contains(pass)
                 )
             }
         }


### PR DESCRIPTION
This removes the double click event of the ShortPassCard to open the barcode because the double click causes a noticeable delay in the onClick action. A full screen barcode is two clicks away anyway (via the pass view).