### PR TITLE
Implement catima compatible content provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Features (non-exhaustive):
 * Attach tags to passes
 * Gadgetbridge integration to get your passes on your watch
 
+### Gadgetbridge integration
+FossWallet integrates with Gadgetbridge, so that you can use your passes barcodes on supported gadgets.
+To sync your passes to a gadget, select it in the gadgetbridge device list, press the cogwheel to
+get to device settings, and go to the "loyalty cards"-menu. There you'll find options to sync passes.
+
+Note:
+* Card groups in Gadgetbridge map to tags in FossWallet
+* Starring is currently not supported, so leave it turned off
+
 ## Installation
 
 [<img src="https://raw.githubusercontent.com/SeineEloquenz/fosswallet/refs/heads/main/.github/badges/github.png"

--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ FossWallet integrates with Gadgetbridge, so that you can use your passes barcode
 To sync your passes to a gadget, select it in the gadgetbridge device list, press the cogwheel to
 get to device settings, and go to the "loyalty cards"-menu. There you'll find options to sync passes.
 
-Note:
-* Card groups in Gadgetbridge map to tags in FossWallet
-* Starring is currently not supported, so leave it turned off
-
 ## Installation
 
 [<img src="https://raw.githubusercontent.com/SeineEloquenz/fosswallet/refs/heads/main/.github/badges/github.png"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Features (non-exhaustive):
 * Compatibility mode for legacy scanners
 * Multiple sort options (incl. by date)
 * Attach tags to passes
+* Gadgetbridge integration to get your passes on your watch
 
 ## Installation
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
         android:description="@string/permission_read_passes_label"
         android:icon="@drawable/icon"
         android:label="@string/permission_read_passes_description"
-        android:name="me.hackerchick.catima.READ_CARDS"
+        android:name="${applicationId}.READ_CARDS"
         android:protectionLevel="dangerous" />
 
     <uses-feature

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <permission
+        android:description="@string/permission_read_passes_label"
+        android:icon="@drawable/icon"
+        android:label="@string/permission_read_passes_description"
+        android:name="me.hackerchick.catima.READ_CARDS"
+        android:protectionLevel="dangerous" />
+
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />
@@ -123,6 +130,12 @@
         <activity
             android:name=".ui.screens.create.ScanActivity"
             android:theme="@style/Theme.FossWallet.NoActionBar"/>
+
+        <provider
+            android:name=".contentprovider.CatimaContentProvider"
+            android:authorities="${applicationId}.contentprovider.cards"
+            android:exported="true"
+            android:readPermission="me.hackerchick.catima.READ_CARDS"/>
 
         <provider
             android:name=".app.PassProvider"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -135,7 +135,7 @@
             android:name=".contentprovider.CatimaContentProvider"
             android:authorities="${applicationId}.contentprovider.cards"
             android:exported="true"
-            android:readPermission="me.hackerchick.catima.READ_CARDS"/>
+            android:readPermission="${applicationId}.READ_CARDS"/>
 
         <provider
             android:name=".app.PassProvider"

--- a/app/src/main/java/nz/eloque/foss_wallet/contentprovider/CatimaContentProvider.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/contentprovider/CatimaContentProvider.kt
@@ -172,7 +172,7 @@ class CatimaContentProvider : ContentProvider() {
             cursor
                 .newRow()
                 .add(CatimaFields.ID, pass.id.hashCode())
-                .add(CatimaFields.STORE, pass.organization)
+                .add(CatimaFields.STORE, pass.logoText ?: pass.organization)
                 .add(
                     CatimaFields.VALID_FROM,
                     pass.relevantDates

--- a/app/src/main/java/nz/eloque/foss_wallet/contentprovider/CatimaContentProvider.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/contentprovider/CatimaContentProvider.kt
@@ -78,6 +78,25 @@ class CatimaContentProvider : ContentProvider() {
         const val STAR_STATUS: String = "starstatus"
         const val LAST_USED: String = "lastused"
         const val ARCHIVE_STATUS: String = "archive"
+
+        val defaultProjection: Array<String> =
+            arrayOf(
+                ID,
+                STORE,
+                VALID_FROM,
+                EXPIRY,
+                BALANCE,
+                BALANCE_TYPE,
+                NOTE,
+                HEADER_COLOR,
+                CARD_ID,
+                BARCODE_ID,
+                BARCODE_TYPE,
+                BARCODE_ENCODING,
+                STAR_STATUS,
+                LAST_USED,
+                ARCHIVE_STATUS,
+            )
     }
 
     private lateinit var passRepository: PassRepository
@@ -115,7 +134,7 @@ class CatimaContentProvider : ContentProvider() {
                         passRepository.all().first()
                     }
 
-                return buildPassesCursor(passes.map { it.pass }, projection)
+                return buildPassesCursor(passes.map { it.pass }, projection ?: CatimaFields.defaultProjection)
             }
 
             URI_GROUPS -> {
@@ -145,7 +164,7 @@ class CatimaContentProvider : ContentProvider() {
 
     private fun buildPassesCursor(
         passes: List<Pass>,
-        columns: Array<String?>?,
+        columns: Array<out String?>,
     ): Cursor {
         val cursor = MatrixCursor(columns)
 
@@ -184,6 +203,7 @@ class CatimaContentProvider : ContentProvider() {
                 .add(CatimaFields.LAST_USED, 0)
                 .add(CatimaFields.ARCHIVE_STATUS, if (pass.archived) 1 else 0)
         }
+
         return cursor
     }
 

--- a/app/src/main/java/nz/eloque/foss_wallet/contentprovider/CatimaContentProvider.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/contentprovider/CatimaContentProvider.kt
@@ -180,7 +180,7 @@ class CatimaContentProvider : ContentProvider() {
                         ?.startDate()
                         ?.toInstant()
                         ?.toEpochMilli() ?: Instant.EPOCH.toEpochMilli(),
-                ).add(CatimaFields.EXPIRY, pass.expirationDate?.toInstant()?.toEpochMilli() ?: Instant.MAX.toEpochMilli())
+                ).add(CatimaFields.EXPIRY, pass.expirationDate?.toInstant()?.toEpochMilli() ?: Long.MAX_VALUE)
                 .add(CatimaFields.BALANCE, 0)
                 .add(CatimaFields.BALANCE_TYPE, null)
                 .add(CatimaFields.NOTE, pass.description)

--- a/app/src/main/java/nz/eloque/foss_wallet/contentprovider/CatimaContentProvider.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/contentprovider/CatimaContentProvider.kt
@@ -185,7 +185,7 @@ class CatimaContentProvider : ContentProvider() {
                 .add(CatimaFields.BALANCE_TYPE, null)
                 .add(CatimaFields.NOTE, pass.description)
                 .add(CatimaFields.HEADER_COLOR, pass.colors?.background)
-                .add(CatimaFields.CARD_ID, pass.id)
+                .add(CatimaFields.CARD_ID, pass.barCodes.firstOrNull()?.altText ?: pass.barCodes.firstOrNull()?.message ?: pass.id)
                 .add(CatimaFields.BARCODE_ID, pass.barCodes.firstOrNull()?.message)
                 .add(
                     CatimaFields.BARCODE_TYPE,

--- a/app/src/main/java/nz/eloque/foss_wallet/contentprovider/CatimaContentProvider.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/contentprovider/CatimaContentProvider.kt
@@ -59,7 +59,7 @@ class CatimaContentProvider : ContentProvider() {
         const val MAJOR_COLUMN: String = "major"
         const val MINOR_COLUMN: String = "minor"
         const val MAJOR: Int = 1
-        const val MINOR: Int = 0
+        const val MINOR: Int = 1
     }
 
     object CatimaFields {
@@ -74,6 +74,7 @@ class CatimaContentProvider : ContentProvider() {
         const val CARD_ID: String = "cardid"
         const val BARCODE_ID: String = "barcodeid"
         const val BARCODE_TYPE: String = "barcodetype"
+        const val BARCODE_ENCODING: String = "barcodeencoding"
         const val STAR_STATUS: String = "starstatus"
         const val LAST_USED: String = "lastused"
         const val ARCHIVE_STATUS: String = "archive"
@@ -172,6 +173,12 @@ class CatimaContentProvider : ContentProvider() {
                     pass.barCodes
                         .firstOrNull()
                         ?.format
+                        .toString(),
+                ).add(
+                    CatimaFields.BARCODE_ENCODING,
+                    pass.barCodes
+                        .firstOrNull()
+                        ?.encoding
                         .toString(),
                 ).add(CatimaFields.STAR_STATUS, 0)
                 .add(CatimaFields.LAST_USED, 0)

--- a/app/src/main/java/nz/eloque/foss_wallet/contentprovider/CatimaContentProvider.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/contentprovider/CatimaContentProvider.kt
@@ -1,0 +1,246 @@
+package nz.eloque.foss_wallet.contentprovider
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.UriMatcher
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.util.Log
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import nz.eloque.foss_wallet.BuildConfig
+import nz.eloque.foss_wallet.model.Pass
+import nz.eloque.foss_wallet.model.PassTagCrossRef
+import nz.eloque.foss_wallet.model.Tag
+import nz.eloque.foss_wallet.persistence.SettingsStore
+import nz.eloque.foss_wallet.persistence.pass.PassRepository
+import nz.eloque.foss_wallet.persistence.tag.TagRepository
+import java.time.Instant
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface ProviderEntrypoint {
+    fun passRepository(): PassRepository
+
+    fun settingsStore(): SettingsStore
+
+    fun tagRepository(): TagRepository
+}
+
+class CatimaContentProvider : ContentProvider() {
+    companion object {
+        private const val TAG = "CatimaContentProvider"
+
+        const val AUTHORITY: String = BuildConfig.APPLICATION_ID + ".contentprovider.cards"
+
+        private const val URI_VERSION = 0
+        private const val URI_CARDS = 1
+        private const val URI_GROUPS = 2
+        private const val URI_CARD_GROUPS = 3
+
+        private val uriMatcher: UriMatcher =
+            object : UriMatcher(NO_MATCH) {
+                init {
+                    addURI(AUTHORITY, "version", URI_VERSION)
+                    addURI(AUTHORITY, "cards", URI_CARDS)
+                    addURI(AUTHORITY, "groups", URI_GROUPS)
+                    addURI(AUTHORITY, "card_groups", URI_CARD_GROUPS)
+                }
+            }
+    }
+
+    object Version {
+        const val MAJOR_COLUMN: String = "major"
+        const val MINOR_COLUMN: String = "minor"
+        const val MAJOR: Int = 1
+        const val MINOR: Int = 0
+    }
+
+    object CatimaFields {
+        const val ID: String = "_id"
+        const val STORE: String = "store"
+        const val VALID_FROM: String = "validfrom"
+        const val EXPIRY: String = "expiry"
+        const val BALANCE: String = "balance"
+        const val BALANCE_TYPE: String = "balancetype"
+        const val NOTE: String = "note"
+        const val HEADER_COLOR: String = "headercolor"
+        const val CARD_ID: String = "cardid"
+        const val BARCODE_ID: String = "barcodeid"
+        const val BARCODE_TYPE: String = "barcodetype"
+        const val STAR_STATUS: String = "starstatus"
+        const val LAST_USED: String = "lastused"
+        const val ARCHIVE_STATUS: String = "archive"
+    }
+
+    private lateinit var passRepository: PassRepository
+    private lateinit var tagRepository: TagRepository
+    private lateinit var settingsStore: SettingsStore
+
+    override fun onCreate(): Boolean {
+        val entryPoint =
+            EntryPointAccessors.fromApplication(
+                context!!.applicationContext,
+                ProviderEntrypoint::class.java,
+            )
+        passRepository = entryPoint.passRepository()
+        tagRepository = entryPoint.tagRepository()
+        settingsStore = entryPoint.settingsStore()
+
+        return true
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<String?>?,
+        selection: String?,
+        selectionArgs: Array<String?>?,
+        sortOrder: String?,
+    ): Cursor? {
+        when (uriMatcher.match(uri)) {
+            URI_VERSION -> {
+                return queryVersion()
+            }
+
+            URI_CARDS -> {
+                val passes =
+                    runBlocking(Dispatchers.IO) {
+                        passRepository.all().first()
+                    }
+
+                return buildPassesCursor(passes.map { it.pass }, projection)
+            }
+
+            URI_GROUPS -> {
+                val tags =
+                    runBlocking(Dispatchers.IO) {
+                        tagRepository.all().first()
+                    }
+
+                return buildTagsCursor(tags)
+            }
+
+            URI_CARD_GROUPS -> {
+                val crossRefs =
+                    runBlocking(Dispatchers.IO) {
+                        tagRepository.crossRef()
+                    }
+
+                return buildCrossRefCursor(crossRefs)
+            }
+
+            else -> {
+                Log.w(TAG, "Unrecognized URI $uri")
+                return null
+            }
+        }
+    }
+
+    private fun buildPassesCursor(
+        passes: List<Pass>,
+        columns: Array<String?>?,
+    ): Cursor {
+        val cursor = MatrixCursor(columns)
+
+        passes.forEach { pass ->
+            cursor
+                .newRow()
+                .add(CatimaFields.ID, pass.id.hashCode())
+                .add(CatimaFields.STORE, pass.organization)
+                .add(
+                    CatimaFields.VALID_FROM,
+                    pass.relevantDates
+                        .firstOrNull()
+                        ?.startDate()
+                        ?.toInstant()
+                        ?.toEpochMilli() ?: Instant.EPOCH.toEpochMilli(),
+                ).add(CatimaFields.EXPIRY, pass.expirationDate?.toInstant()?.toEpochMilli() ?: Instant.MAX.toEpochMilli())
+                .add(CatimaFields.BALANCE, 0)
+                .add(CatimaFields.BALANCE_TYPE, null)
+                .add(CatimaFields.NOTE, pass.description)
+                .add(CatimaFields.HEADER_COLOR, pass.colors?.background)
+                .add(CatimaFields.CARD_ID, pass.id)
+                .add(CatimaFields.BARCODE_ID, pass.barCodes.firstOrNull()?.message)
+                .add(
+                    CatimaFields.BARCODE_TYPE,
+                    pass.barCodes
+                        .firstOrNull()
+                        ?.format
+                        .toString(),
+                ).add(CatimaFields.STAR_STATUS, 0)
+                .add(CatimaFields.LAST_USED, 0)
+                .add(CatimaFields.ARCHIVE_STATUS, if (pass.archived) 1 else 0)
+        }
+        return cursor
+    }
+
+    private fun buildTagsCursor(tags: Set<Tag>): Cursor {
+        val cursor = MatrixCursor(arrayOf("_id", "orderId"))
+
+        tags.sortedBy { it.label }.forEachIndexed { index, tag ->
+            cursor
+                .newRow()
+                .add("_id", tag.label)
+                .add("orderId", index)
+        }
+        return cursor
+    }
+
+    private fun buildCrossRefCursor(crossRefs: List<PassTagCrossRef>): Cursor {
+        val cursor = MatrixCursor(arrayOf("cardId", "groupId"))
+
+        crossRefs.forEach { crossRef ->
+            cursor
+                .newRow()
+                .add("cardId", crossRef.passId)
+                .add("groupId", crossRef.tagLabel)
+        }
+        return cursor
+    }
+
+    private fun queryVersion(): Cursor {
+        val columns: Array<String?> = arrayOf(Version.MAJOR_COLUMN, Version.MINOR_COLUMN)
+        val matrixCursor = MatrixCursor(columns)
+        matrixCursor.addRow(arrayOf<Any>(Version.MAJOR, Version.MINOR))
+
+        return matrixCursor
+    }
+
+    override fun getType(uri: Uri): String? {
+        // MIME types are not relevant (for now at least)
+        return null
+    }
+
+    override fun insert(
+        uri: Uri,
+        values: ContentValues?,
+    ): Uri? {
+        // This content provider is read-only for now, so we always return null
+        return null
+    }
+
+    override fun delete(
+        uri: Uri,
+        selection: String?,
+        selectionArgs: Array<String?>?,
+    ): Int {
+        // This content provider is read-only for now, so we always return 0
+        return 0
+    }
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<String?>?,
+    ): Int {
+        // This content provider is read-only for now, so we always return 0
+        return 0
+    }
+}

--- a/app/src/main/java/nz/eloque/foss_wallet/contentprovider/CatimaContentProvider.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/contentprovider/CatimaContentProvider.kt
@@ -7,6 +7,7 @@ import android.database.Cursor
 import android.database.MatrixCursor
 import android.net.Uri
 import android.util.Log
+import androidx.compose.ui.graphics.toArgb
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
@@ -184,7 +185,7 @@ class CatimaContentProvider : ContentProvider() {
                 .add(CatimaFields.BALANCE, 0)
                 .add(CatimaFields.BALANCE_TYPE, null)
                 .add(CatimaFields.NOTE, pass.description)
-                .add(CatimaFields.HEADER_COLOR, pass.colors?.background)
+                .add(CatimaFields.HEADER_COLOR, pass.colors?.background?.toArgb())
                 .add(CatimaFields.CARD_ID, pass.barCodes.firstOrNull()?.altText ?: pass.barCodes.firstOrNull()?.message ?: pass.id)
                 .add(CatimaFields.BARCODE_ID, pass.barCodes.firstOrNull()?.message)
                 .add(

--- a/app/src/main/java/nz/eloque/foss_wallet/model/BarCode.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/BarCode.kt
@@ -10,9 +10,9 @@ import org.json.JSONObject
 import java.nio.charset.Charset
 
 data class BarCode(
-    private val format: BarcodeFormat,
-    private val message: String,
-    private val encoding: Charset,
+    val format: BarcodeFormat,
+    val message: String,
+    val encoding: Charset,
     val altText: String?,
 ) {
     fun toJson(): JSONObject =

--- a/app/src/main/java/nz/eloque/foss_wallet/persistence/tag/TagDao.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/persistence/tag/TagDao.kt
@@ -7,6 +7,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
+import nz.eloque.foss_wallet.model.PassTagCrossRef
 import nz.eloque.foss_wallet.model.Tag
 
 @Dao
@@ -14,6 +15,10 @@ interface TagDao {
     @Transaction
     @Query("SELECT * FROM tag")
     fun all(): Flow<List<Tag>>
+
+    @Transaction
+    @Query("SELECT * FROM PassTag")
+    suspend fun crossRef(): List<PassTagCrossRef>
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(tag: Tag)

--- a/app/src/main/java/nz/eloque/foss_wallet/persistence/tag/TagRepository.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/persistence/tag/TagRepository.kt
@@ -14,6 +14,8 @@ class TagRepository
     ) {
         fun all() = tagDao.all().map { it.toSet() }
 
+        suspend fun crossRef() = tagDao.crossRef()
+
         suspend fun insert(tag: Tag) = tagDao.insert(tag)
 
         suspend fun remove(tag: Tag) = tagDao.remove(tag)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,4 +131,6 @@
     <string name="no_calendar_app_found">No calendar app found</string>
     <string name="created_pass_export_warning">Created passes can currently not be exported</string>
     <string name="show_archived_passes">Show archived passes</string>
+    <string name="permission_read_passes_label">Read Passes</string>
+    <string name="permission_read_passes_description">Read your passes and their details, including barcodes in a Catima compatible way</string>
 </resources>


### PR DESCRIPTION
This should provide the necessary functionality to get a [Gadgetbridge](https://codeberg.org/Freeyourgadget/Gadgetbridge) integration going with minimal friction.
Gadgetbridge issue [here](https://codeberg.org/Freeyourgadget/Gadgetbridge/issues/6000).

Catima implemented such a ContentProvider in https://github.com/CatimaLoyalty/Android/pull/1121, and the corresponding code on GadgetBridge's end was implemented in https://codeberg.org/Freeyourgadget/Gadgetbridge/pulls/2953.

If I understand their code correctly, by us implementing a compatible ContentProvider, GadgetBridge should be able to pull our passes, simply by adding our package id to their Catima code.