### PR TITLE
Improve localization parsing and matching

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/model/PassWithLocalization.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/PassWithLocalization.kt
@@ -4,6 +4,7 @@ import androidx.room.Embedded
 import androidx.room.Relation
 import nz.eloque.foss_wallet.model.field.PassContent
 import nz.eloque.foss_wallet.model.field.PassField
+import java.util.Locale
 
 private const val CHANGE_MESSAGE_FORMAT = "%@"
 
@@ -49,9 +50,21 @@ data class PassWithLocalization(
             this
         }
 
-    private fun localeMapping(locale: String): Map<String, PassLocalization> =
-        localizations
-            .filter {
-                it.lang == locale
-            }.associateBy { it.label }
+    private fun localeMapping(locale: String): Map<String, PassLocalization> {
+        val availableLanguageTags = localizations.map { it.lang.normalizedLanguageTag() }.distinct()
+        val preferredLanguages = listOf(locale, "en")
+        val bestMatch =
+            Locale.lookupTag(
+                preferredLanguages.mapNotNull { it.normalizedLanguageTag().toLanguageRangeOrNull() },
+                availableLanguageTags,
+            ) ?: "en"
+
+        return localizations
+            .filter { it.lang.normalizedLanguageTag().equals(bestMatch, ignoreCase = true) }
+            .associateBy { it.label }
+    }
+
+    private fun String.normalizedLanguageTag(): String = replace('_', '-')
+
+    private fun String.toLanguageRangeOrNull(): Locale.LanguageRange? = runCatching { Locale.LanguageRange(this) }.getOrNull()
 }

--- a/app/src/main/java/nz/eloque/foss_wallet/model/PassWithLocalization.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/PassWithLocalization.kt
@@ -18,7 +18,7 @@ data class PassWithLocalization(
     val localizations: List<PassLocalization>,
 ) {
     fun applyLocalization(locale: String): Pass {
-        val mapping = localeMapping(locale).ifEmpty { localeMapping("en") }
+        val mapping = localeMapping(locale)
         return pass.copy(
             description = mapping[pass.description]?.text ?: pass.description,
             headerFields = pass.headerFields.applyLocalization(mapping),

--- a/app/src/main/java/nz/eloque/foss_wallet/model/PassWithTagsAndLocalization.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/PassWithTagsAndLocalization.kt
@@ -5,6 +5,7 @@ import androidx.room.Junction
 import androidx.room.Relation
 import nz.eloque.foss_wallet.model.field.PassContent
 import nz.eloque.foss_wallet.model.field.PassField
+import java.util.Locale
 
 private const val CHANGE_MESSAGE_FORMAT = "%@"
 
@@ -64,9 +65,21 @@ data class PassWithTagsAndLocalization(
             this
         }
 
-    private fun localeMapping(locale: String): Map<String, PassLocalization> =
-        localizations
-            .filter {
-                it.lang == locale
-            }.associateBy { it.label }
+    private fun localeMapping(locale: String): Map<String, PassLocalization> {
+        val availableLanguageTags = localizations.map { it.lang.normalizedLanguageTag() }.distinct()
+        val preferredLanguages = listOf(locale, "en")
+        val bestMatch =
+            Locale.lookupTag(
+                preferredLanguages.mapNotNull { it.normalizedLanguageTag().toLanguageRangeOrNull() },
+                availableLanguageTags,
+            ) ?: "en"
+
+        return localizations
+            .filter { it.lang.normalizedLanguageTag().equals(bestMatch, ignoreCase = true) }
+            .associateBy { it.label }
+    }
+
+    private fun String.normalizedLanguageTag(): String = replace('_', '-')
+
+    private fun String.toLanguageRangeOrNull(): Locale.LanguageRange? = runCatching { Locale.LanguageRange(this) }.getOrNull()
 }

--- a/app/src/main/java/nz/eloque/foss_wallet/model/PassWithTagsAndLocalization.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/PassWithTagsAndLocalization.kt
@@ -30,7 +30,7 @@ data class PassWithTagsAndLocalization(
     val localizations: List<PassLocalization>,
 ) {
     fun applyLocalization(locale: String): LocalizedPassWithTags {
-        val mapping = localeMapping(locale).ifEmpty { localeMapping("en") }
+        val mapping = localeMapping(locale)
         val localizedPass =
             pass.copy(
                 description = mapping[pass.description]?.text ?: pass.description,

--- a/app/src/main/java/nz/eloque/foss_wallet/persistence/loader/PassLoader.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/persistence/loader/PassLoader.kt
@@ -127,8 +127,8 @@ class PassLoader(
                             footer = chooseBetter(footer, loadImage(baos))
                         }
 
-                        in Regex("..\\.lproj/pass.strings") -> {
-                            localizations.addAll(parseLocalization(entry.name.substring(0, 2), baos))
+                        in LOCALIZATION_FILE_REGEX -> {
+                            localizations.addAll(parseLocalization(entry.name.substringBefore(".lproj"), baos))
                         }
                     }
                 }
@@ -198,5 +198,7 @@ class PassLoader(
 
     companion object {
         private const val TAG = "PassLoader"
+        private val LOCALIZATION_FILE_REGEX =
+            Regex("^[A-Za-z]{2,3}(?:[-_][A-Za-z0-9]{2,8})*\\.lproj/pass\\.strings$")
     }
 }


### PR DESCRIPTION
- Support localizations with script tags like `en-US`, `en-GB` or `zh-Hans`.
- Use `Locale.lookupTag()` to properly find a best match in available languages.

Since the code logic was already duplicated, new code is not deduped. This can be handled later.