### PR TITLE
Use the smallest possible size of the barcode for the legacy representation check

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/model/BarCode.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/BarCode.kt
@@ -1,11 +1,12 @@
 package nz.eloque.foss_wallet.model
 
 import android.graphics.Bitmap
+import android.graphics.Bitmap.createBitmap
 import android.graphics.Color
-import androidx.core.graphics.createBitmap
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.EncodeHintType
 import com.google.zxing.MultiFormatWriter
+import com.google.zxing.common.BitMatrix
 import org.json.JSONObject
 import java.nio.charset.Charset
 
@@ -45,35 +46,46 @@ data class BarCode(
         }
 
     fun hasLegacyRepresentation(): Boolean {
-        val legacyRepresentation = encodeAsBitmap(100, 100, true)
-        val representation = encodeAsBitmap(100, 100, false)
-        return !(representation?.sameAs(legacyRepresentation) ?: false)
+        val legacyRepresentation = encode(legacyRendering = true) ?: return false
+        val representation = encode(legacyRendering = false) ?: return false
+
+        return representation != legacyRepresentation
     }
 
-    fun encodeAsBitmap(
-        width: Int,
-        height: Int,
-        legacyRendering: Boolean,
-    ): Bitmap? {
+    fun isNotValid() = encode() == null
+
+    private fun encode(
+        width: Int = 0,
+        height: Int = 0,
+        legacyRendering: Boolean = false,
+    ): BitMatrix? {
         val encodeHints = mapOf(Pair(EncodeHintType.CHARACTER_SET, encoding))
-        val result =
-            try {
-                MultiFormatWriter().encode(message, format, width, height, if (legacyRendering) null else encodeHints)
-            } catch (_: Exception) {
-                return null
-            }
-        val w = result.width
-        val h = result.height
+
+        return try {
+            MultiFormatWriter().encode(message, format, width, height, if (legacyRendering) null else encodeHints)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    fun toBitmap(
+        width: Int = 0,
+        height: Int = 0,
+        legacyRendering: Boolean = false,
+    ): Bitmap? {
+        val bitMatrix = encode(width, height, legacyRendering) ?: return null
+
+        val w = bitMatrix.width
+        val h = bitMatrix.height
         val pixels = IntArray(w * h)
         for (y in 0 until h) {
             val offset = y * w
             for (x in 0 until w) {
-                pixels[offset + x] = if (result[x, y]) Color.BLACK else Color.WHITE
+                pixels[offset + x] = if (bitMatrix[x, y]) Color.BLACK else Color.WHITE
             }
         }
-        val bitmap = createBitmap(w, h)
-        bitmap.setPixels(pixels, 0, w, 0, 0, w, h)
-        return bitmap
+
+        return createBitmap(pixels, w, h, Bitmap.Config.ARGB_8888)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/app/src/main/java/nz/eloque/foss_wallet/model/PassCreator.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/PassCreator.kt
@@ -59,19 +59,7 @@ object PassCreator {
         auxiliaryFields: List<PassField> = emptyList(),
         backFields: List<PassField> = emptyList(),
     ): Pass? {
-        if (barCodes.isEmpty()) {
-            return null
-        }
-
-        if (barCodes.any {
-                try {
-                    it.encodeAsBitmap(100, 100, false)
-                    false
-                } catch (_: IllegalArgumentException) {
-                    true
-                }
-            }
-        ) {
+        if (barCodes.isEmpty() || barCodes.any { it.isNotValid() }) {
             return null
         }
 

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/CreateView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/CreateView.kt
@@ -167,7 +167,7 @@ fun CreateView(
     val barcodesValid =
         barcodes.isNotEmpty() &&
             barcodes.zip(barCodeModels).all { (draft, model) ->
-                draft.message.isNotEmpty() && barcodeValid(model)
+                draft.message.isNotEmpty() && !model.isNotValid()
             }
     val datesValid = relevantEnd == null || relevantStart != null
     val createValid = nameValid && barcodesValid && datesValid && pass != null && !isSaving
@@ -244,6 +244,15 @@ fun CreateView(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             barcodes.forEachIndexed { index, barcode ->
+                val isNotValid =
+                    barcode.message.isNotEmpty() &&
+                        BarCode(
+                            format = barcode.format,
+                            message = barcode.message,
+                            encoding = Charsets.UTF_8,
+                            altText = barcode.altText.ifBlank { barcode.message },
+                        ).isNotValid()
+
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -259,27 +268,9 @@ fun CreateView(
                                 }
                         },
                         modifier = Modifier.fillMaxWidth(fraction = 0.72f),
-                        isError =
-                            barcode.message.isNotEmpty() &&
-                                !barcodeValid(
-                                    BarCode(
-                                        format = barcode.format,
-                                        message = barcode.message,
-                                        encoding = Charsets.UTF_8,
-                                        altText = barcode.altText.ifBlank { barcode.message },
-                                    ),
-                                ),
+                        isError = isNotValid,
                         supportingText = {
-                            if (barcode.message.isNotEmpty() &&
-                                !barcodeValid(
-                                    BarCode(
-                                        format = barcode.format,
-                                        message = barcode.message,
-                                        encoding = Charsets.UTF_8,
-                                        altText = barcode.altText.ifBlank { barcode.message },
-                                    ),
-                                )
-                            ) {
+                            if (isNotValid) {
                                 Text(stringResource(R.string.barcode_value_invalid, barcode.format.toString()))
                             }
                         },
@@ -962,8 +953,6 @@ private data class BarcodeDraft(
     val altText: String,
     val format: BarcodeFormat,
 )
-
-private fun barcodeValid(barCode: BarCode): Boolean = barCode.encodeAsBitmap(100, 100, false) != null
 
 private fun Double.formatCoord(): String = String.format(Locale.current.platformLocale, "%.6f", this)
 

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/pass/PassViewComponents.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/pass/PassViewComponents.kt
@@ -87,7 +87,7 @@ fun BarcodesView(
                 ) { index ->
                     val barcode = barcodes[index]
                     val image =
-                        barcode.encodeAsBitmap(
+                        barcode.toBitmap(
                             if (barcode.is1d()) 3000 else 1000,
                             1000,
                             legacyRendering,
@@ -136,7 +136,7 @@ fun BarcodesView(
     fullscreenIndex?.let { index ->
         val fullscreenBarcode = barcodes.getOrNull(index) ?: return@let
         val fullscreenImage =
-            fullscreenBarcode.encodeAsBitmap(
+            fullscreenBarcode.toBitmap(
                 if (fullscreenBarcode.is1d()) 3000 else 1000,
                 1000,
                 legacyRendering,


### PR DESCRIPTION
ZXing uses the smallest possible size when the requested size of the `encode()` function is smaller than the barcode. That prevents an unnecessary upscaling of the barcode when using `hasLegacyRepresenation()`. Furthermore, there is no need to generate the bitmap in such a case either and instead, we can directly compare the two BitMatrixes.

The same applies to the check in `CreateView()`.