### PR TITLE
Fix auto archive test after the latest code changes

### DIFF
--- a/app/src/androidTest/java/nz/eloque/foss_wallet/persistence/pass/AutoArchiveBehaviorTest.kt
+++ b/app/src/androidTest/java/nz/eloque/foss_wallet/persistence/pass/AutoArchiveBehaviorTest.kt
@@ -3,7 +3,9 @@ package nz.eloque.foss_wallet.persistence.pass
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.test.runTest
 import nz.eloque.foss_wallet.model.Pass
+import nz.eloque.foss_wallet.model.PassMetadata
 import nz.eloque.foss_wallet.model.PassType
 import nz.eloque.foss_wallet.persistence.WalletDb
 import org.junit.After
@@ -44,63 +46,67 @@ class AutoArchiveBehaviorTest {
     }
 
     @Test
-    fun passIsAutoArchivedOnceButNotAfterUnarchive() {
-        val pass =
-            Pass(
-                id = "expired-pass",
-                description = "Expired pass",
-                formatVersion = 1,
-                organization = "Test Org",
-                serialNumber = "123",
-                type = PassType.Generic,
-                barCodes = setOf(),
-                addedAt = fixedNow,
-                expirationDate = fixedExpiredDate,
-            )
-        passDao.insert(pass)
+    fun passIsAutoArchivedOnceButNotAfterUnarchive() =
+        runTest {
+            val pass =
+                Pass(
+                    id = "expired-pass",
+                    description = "Expired pass",
+                    formatVersion = 1,
+                    organization = "Test Org",
+                    serialNumber = "123",
+                    type = PassType.Generic,
+                    barCodes = setOf(),
+                    addedAt = fixedNow,
+                    expirationDate = fixedExpiredDate,
+                )
+            passDao.insert(pass)
+            passDao.insert(PassMetadata(pass.id))
 
-        passRepository.archiveExpiredPasses(now = fixedNow)
+            passRepository.archiveExpiredPasses(now = fixedNow)
 
-        val afterFirstAutoArchiveRun = passDao.findById(pass.id)?.pass
-        assertNotNull(afterFirstAutoArchiveRun)
-        assertTrue(afterFirstAutoArchiveRun!!.archived)
-        assertTrue(afterFirstAutoArchiveRun.autoArchive)
+            val afterFirstAutoArchiveRun = passDao.findById(pass.id)?.metadata
+            assertNotNull(afterFirstAutoArchiveRun)
+            assertTrue(afterFirstAutoArchiveRun!!.archived)
+            assertTrue(afterFirstAutoArchiveRun.autoArchive)
 
-        passDao.unarchive(pass.id)
-        val afterUnarchive = passDao.findById(pass.id)?.pass
-        assertNotNull(afterUnarchive)
-        assertFalse(afterUnarchive!!.archived)
-        assertFalse(afterUnarchive.autoArchive)
+            passDao.unarchive(pass.id)
+            val afterUnarchive = passDao.findById(pass.id)?.metadata
+            assertNotNull(afterUnarchive)
+            assertFalse(afterUnarchive!!.archived)
+            assertFalse(afterUnarchive.autoArchive)
 
-        passRepository.archiveExpiredPasses(now = fixedNow)
+            passRepository.archiveExpiredPasses(now = fixedNow)
 
-        val afterAutoArchiveRun = passDao.findById(pass.id)?.pass
-        assertNotNull(afterAutoArchiveRun)
-        assertFalse(afterAutoArchiveRun!!.archived)
-        assertFalse(afterAutoArchiveRun.autoArchive)
-    }
+            val afterAutoArchiveRun = passDao.findById(pass.id)?.metadata
+            assertNotNull(afterAutoArchiveRun)
+            assertFalse(afterAutoArchiveRun!!.archived)
+            assertFalse(afterAutoArchiveRun.autoArchive)
+        }
 
     @Test
-    fun nonExpiredPassDoesNotGetArchived() {
-        val nonExpiredPass =
-            Pass(
-                id = "non-expired-pass",
-                description = "Not yet expired pass",
-                formatVersion = 1,
-                organization = "Test Org",
-                serialNumber = "125",
-                type = PassType.Generic,
-                barCodes = setOf(),
-                addedAt = fixedNow,
-                expirationDate = fixedFutureDate,
-            )
-        passDao.insert(nonExpiredPass)
+    fun nonExpiredPassDoesNotGetArchived() =
+        runTest {
+            val nonExpiredPass =
+                Pass(
+                    id = "non-expired-pass",
+                    description = "Not yet expired pass",
+                    formatVersion = 1,
+                    organization = "Test Org",
+                    serialNumber = "125",
+                    type = PassType.Generic,
+                    barCodes = setOf(),
+                    addedAt = fixedNow,
+                    expirationDate = fixedFutureDate,
+                )
+            passDao.insert(nonExpiredPass)
+            passDao.insert(PassMetadata(nonExpiredPass.id))
 
-        passRepository.archiveExpiredPasses(now = fixedNow)
+            passRepository.archiveExpiredPasses(now = fixedNow)
 
-        val afterAutoArchiveRun = passDao.findById(nonExpiredPass.id)?.pass
-        assertNotNull(afterAutoArchiveRun)
-        assertFalse(afterAutoArchiveRun!!.archived)
-        assertTrue(afterAutoArchiveRun.autoArchive)
-    }
+            val afterAutoArchiveRun = passDao.findById(nonExpiredPass.id)?.metadata
+            assertNotNull(afterAutoArchiveRun)
+            assertFalse(afterAutoArchiveRun!!.archived)
+            assertTrue(afterAutoArchiveRun.autoArchive)
+        }
 }


### PR DESCRIPTION
This is also necessary in order to be able to run a composable preview on a device because this needs the assembleDebugAndroidTest task.

- `runTest()` is needed to be able to call the suspending function `archiveExpiredPasses()`
- The archive state of the pass is now part of the metadata of the pass
