### PR TITLE
Improve the icons of the different types of a boarding pass

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/model/TransitType.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/TransitType.kt
@@ -1,12 +1,12 @@
 package nz.eloque.foss_wallet.model
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Forward
 import androidx.compose.material.icons.filled.DirectionsBoat
 import androidx.compose.material.icons.filled.DirectionsBus
-import androidx.compose.material.icons.filled.DirectionsTransit
-import androidx.compose.material.icons.filled.KeyboardDoubleArrowRight
+import androidx.compose.material.icons.filled.Train
 import androidx.compose.ui.graphics.vector.ImageVector
-import nz.eloque.foss_wallet.ui.icons.FlightTakeoff
+import nz.eloque.foss_wallet.ui.icons.Flight
 
 private const val AIR_KEY = "PKTransitTypeAir"
 private const val BOAT_KEY = "PKTransitTypeBoat"
@@ -18,11 +18,11 @@ enum class TransitType(
     val jsonKey: String,
     val icon: ImageVector,
 ) {
-    GENERIC(GENERIC_KEY, Icons.Default.KeyboardDoubleArrowRight),
-    AIR(AIR_KEY, Icons.AutoMirrored.Default.FlightTakeoff),
+    GENERIC(GENERIC_KEY, Icons.AutoMirrored.Default.Forward),
+    AIR(AIR_KEY, Icons.AutoMirrored.Default.Flight),
     BOAT(BOAT_KEY, Icons.Default.DirectionsBoat),
     BUS(BUS_KEY, Icons.Default.DirectionsBus),
-    TRAIN(TRAIN_KEY, Icons.Default.DirectionsTransit),
+    TRAIN(TRAIN_KEY, Icons.Default.Train),
     ;
 
     companion object {

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/icons/AutoMirrored.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/icons/AutoMirrored.kt
@@ -5,40 +5,37 @@ import androidx.compose.material.icons.materialIcon
 import androidx.compose.material.icons.materialPath
 import androidx.compose.ui.graphics.vector.ImageVector
 
-val Icons.AutoMirrored.Filled.FlightTakeoff: ImageVector
+val Icons.AutoMirrored.Filled.Flight: ImageVector
     get() {
-        if (flightTakeoff != null) {
-            return flightTakeoff!!
+        if (flight != null) {
+            return flight!!
         }
-        flightTakeoff =
-            materialIcon(
-                name = "AutoMirrored.Filled.AirplaneTicket",
-                autoMirror =
-                true,
-            ) {
+        flight =
+            materialIcon(name = "AutoMirrored.Filled.Flight", autoMirror = true) {
                 materialPath {
-                    moveTo(2.5f, 19.0f)
-                    horizontalLineToRelative(19.0f)
-                    verticalLineToRelative(2.0f)
-                    horizontalLineToRelative(-19.0f)
-                    verticalLineTo(19.0f)
-                    close()
-                    moveTo(22.07f, 9.64f)
-                    curveToRelative(-0.21f, -0.8f, -1.04f, -1.28f, -1.84f, -1.06f)
-                    lineTo(14.92f, 10.0f)
-                    lineToRelative(-6.9f, -6.43f)
-                    lineTo(6.09f, 4.08f)
-                    lineToRelative(4.14f, 7.17f)
-                    lineToRelative(-4.97f, 1.33f)
-                    lineToRelative(-1.97f, -1.54f)
-                    lineToRelative(-1.45f, 0.39f)
-                    lineToRelative(2.59f, 4.49f)
-                    curveToRelative(0.0f, 0.0f, 7.12f, -1.9f, 16.57f, -4.43f)
-                    curveTo(21.81f, 11.26f, 22.28f, 10.44f, 22.07f, 9.64f)
+                    moveTo(8.0f, 21.0f)
+                    horizontalLineToRelative(2.0f)
+                    lineToRelative(5.0f, -8.0f)
+                    horizontalLineTo(20.5f)
+                    curveToRelative(0.83f, 0.0f, 1.5f, -0.67f, 1.5f, -1.5f)
+                    reflectiveCurveTo(24f - 2.67f, 10.0f, 24f - 3.5f, 10.0f)
+                    horizontalLineTo(15.0f)
+                    lineToRelative(-5.0f, -8.0f)
+                    horizontalLineToRelative(-2.0f)
+                    lineToRelative(2.5f, 8.0f)
+                    horizontalLineTo(5.0f)
+                    lineToRelative(-1.5f, -2.0f)
+                    horizontalLineTo(2.0f)
+                    lineToRelative(1.0f, 3.5f)
+                    lineToRelative(-1.0f, 3.5f)
+                    horizontalLineToRelative(1.5f)
+                    lineTo(5.0f, 13.0f)
+                    horizontalLineToRelative(5.5f)
+                    lineToRelative(-2.5f, 8.0f)
                     close()
                 }
             }
-        return flightTakeoff!!
+        return flight!!
     }
 
-private var flightTakeoff: ImageVector? = null
+private var flight: ImageVector? = null


### PR DESCRIPTION
This improves the different icons used in the boarding pass primary to better match the ones used in Apple Wallet.

- **Generic:** Use automirrored arrow to also take into account the layout direction.
- **Fligh:** This is a copy of `Icons.Filled.Flight`, but roated 90 degrees clockwise. This is done by first swapping the x and y coordinates. Aftwards the icon is flipped by changing the sign of the x coordinate of relative movements. For absolute movements the x coordinate is substracted from the width of the icon (24px) instead.
- **Train:** In my opinion, `Icons.Filled.Train` depicts a train on tracks better than `Icons.Filled.DirectionsTransit`

| **Before** | **After** |
|:----------:|:---------:|
| <img width="50" src="https://github.com/user-attachments/assets/596fecf0-9521-41e8-9fa8-7d35d3d031ab" /> | <img width="50" src="https://github.com/user-attachments/assets/1596fb7e-18ef-4dd7-b99a-57ed178ba95f" /> |
