### PR TITLE
Use foreground color if label color does not exist

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/parsing/PassParser.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/parsing/PassParser.kt
@@ -213,7 +213,7 @@ class PassParser(
     private fun parsePassColors(passJson: JSONObject): PassColors? {
         val background = parseColor("backgroundColor", passJson)
         val foreground = parseColor("foregroundColor", passJson)
-        val label = parseColor("labelColor", passJson)
+        val label = parseColor("labelColor", passJson) ?: foreground
         return if (background != null && foreground != null && label != null) {
             PassColors(background, foreground, label)
         } else {


### PR DESCRIPTION
This prevents the attempt to determine fallback colors from the logo of the pass when only the field `labelColor` is missing.