### PR TITLE
Feature/improve image barcode scanning

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/BarcodeReaders.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/BarcodeReaders.kt
@@ -3,15 +3,18 @@ package nz.eloque.foss_wallet.ui.screens.create
 import zxingcpp.BarcodeReader
 
 object BarcodeReaders {
+    val primary =
+        BarcodeReader(
+            BarcodeReader.Options(
+                tryHarder = true,
+                tryRotate = true,
+                tryInvert = true,
+            ),
+        )
+
     val decoders =
         listOf(
-            BarcodeReader(
-                BarcodeReader.Options(
-                    tryHarder = true,
-                    tryRotate = true,
-                    tryInvert = true,
-                ),
-            ),
+            primary,
             BarcodeReader(
                 BarcodeReader.Options(
                     tryHarder = true,

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/BarcodeReaders.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/BarcodeReaders.kt
@@ -1,0 +1,38 @@
+package nz.eloque.foss_wallet.ui.screens.create
+
+import zxingcpp.BarcodeReader
+
+object BarcodeReaders {
+    val decoders =
+        listOf(
+            BarcodeReader(
+                BarcodeReader.Options(
+                    tryHarder = true,
+                    tryRotate = true,
+                    tryInvert = true,
+                ),
+            ),
+            BarcodeReader(
+                BarcodeReader.Options(
+                    tryHarder = true,
+                    tryRotate = true,
+                    tryInvert = true,
+                    tryDenoise = true,
+                    tryDownscale = false,
+                    binarizer = BarcodeReader.Binarizer.GLOBAL_HISTOGRAM,
+                ),
+            ),
+        )
+
+    val symbolLocator =
+        BarcodeReader(
+            BarcodeReader.Options(
+                tryHarder = true,
+                tryRotate = true,
+                tryInvert = true,
+                tryDenoise = true,
+                tryDownscale = false,
+                returnErrors = true,
+            ),
+        )
+}

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/ImageScanner.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/ImageScanner.kt
@@ -2,17 +2,49 @@ package nz.eloque.foss_wallet.ui.screens.create
 
 import android.content.ContentResolver
 import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
 import android.graphics.ImageDecoder
+import android.graphics.Matrix
+import android.graphics.Paint
 import android.net.Uri
 import zxingcpp.BarcodeReader
+import kotlin.math.hypot
+import kotlin.math.max
 
 object ImageScanner {
-    private val barcodeReader =
+    private val barcodeReaders =
+        listOf(
+            BarcodeReader(
+                BarcodeReader.Options(
+                    tryHarder = true,
+                    tryRotate = true,
+                    tryInvert = true,
+                ),
+            ),
+            BarcodeReader(
+                BarcodeReader.Options(
+                    tryHarder = true,
+                    tryRotate = true,
+                    tryInvert = true,
+                    tryDenoise = true,
+                    tryDownscale = false,
+                    binarizer = BarcodeReader.Binarizer.GLOBAL_HISTOGRAM,
+                ),
+            ),
+        )
+
+    private val symbolLocator =
         BarcodeReader(
             BarcodeReader.Options(
                 tryHarder = true,
                 tryRotate = true,
                 tryInvert = true,
+                tryDenoise = true,
+                tryDownscale = false,
+                returnErrors = true,
             ),
         )
 
@@ -35,11 +67,175 @@ object ImageScanner {
     }
 
     fun scanFrom(bitmap: Bitmap): ScanResult? {
-        val result = barcodeReader.read(bitmap).firstOrNull() ?: return null
+        scanBitmap(bitmap)?.let { return it }
+
+        val position =
+            symbolLocator
+                .read(bitmap)
+                .firstOrNull()
+                ?.position
+                ?: return null
+
+        for (correctedBitmap in perspectiveCorrectionCandidates(bitmap, position)) {
+            scanBitmap(correctedBitmap)?.let { return it }
+        }
+
+        return null
+    }
+
+    private fun scanBitmap(bitmap: Bitmap): ScanResult? {
+        val result =
+            barcodeReaders
+                .asSequence()
+                .flatMap { it.read(bitmap).asSequence() }
+                .firstOrNull { it.error == null }
+                ?: return null
         val text = result.text?.takeIf { it.isNotBlank() } ?: return null
         return ScanResult(
             text = text,
             format = result.format.name,
         )
     }
+
+    private fun perspectiveCorrectionCandidates(
+        bitmap: Bitmap,
+        position: BarcodeReader.Position,
+    ): List<Bitmap> {
+        val points =
+            floatArrayOf(
+                position.topLeft.x.toFloat(),
+                position.topLeft.y.toFloat(),
+                position.topRight.x.toFloat(),
+                position.topRight.y.toFloat(),
+                position.bottomRight.x.toFloat(),
+                position.bottomRight.y.toFloat(),
+                position.bottomLeft.x.toFloat(),
+                position.bottomLeft.y.toFloat(),
+            )
+
+        return listOf(1.35f, 1.8f)
+            .flatMap { scale ->
+                val expandedPoints = expandAroundCenter(points, scale)
+                val corrected = perspectiveCorrect(bitmap, expandedPoints)
+                listOf(corrected, enhanceContrast(corrected))
+            }
+    }
+
+    private fun expandAroundCenter(
+        points: FloatArray,
+        scale: Float,
+    ): FloatArray {
+        var centerX = 0f
+        var centerY = 0f
+        for (index in points.indices step 2) {
+            centerX += points[index]
+            centerY += points[index + 1]
+        }
+        centerX /= 4f
+        centerY /= 4f
+
+        return FloatArray(points.size) { index ->
+            val center = if (index % 2 == 0) centerX else centerY
+            center + (points[index] - center) * scale
+        }
+    }
+
+    private fun perspectiveCorrect(
+        bitmap: Bitmap,
+        sourcePoints: FloatArray,
+    ): Bitmap {
+        val width =
+            max(
+                distance(sourcePoints, 0, 2),
+                distance(sourcePoints, 6, 4),
+            ).toInt()
+        val height =
+            max(
+                distance(sourcePoints, 0, 6),
+                distance(sourcePoints, 2, 4),
+            ).toInt()
+        val margin = max(24, height / 4)
+
+        val destinationPoints =
+            floatArrayOf(
+                margin.toFloat(),
+                margin.toFloat(),
+                (width + margin).toFloat(),
+                margin.toFloat(),
+                (width + margin).toFloat(),
+                (height + margin).toFloat(),
+                margin.toFloat(),
+                (height + margin).toFloat(),
+            )
+
+        val matrix =
+            Matrix().apply {
+                setPolyToPoly(sourcePoints, 0, destinationPoints, 0, 4)
+            }
+        val output =
+            Bitmap.createBitmap(
+                width + margin * 2,
+                height + margin * 2,
+                Bitmap.Config.ARGB_8888,
+            )
+        Canvas(output).apply {
+            drawColor(Color.WHITE)
+            drawBitmap(
+                bitmap,
+                matrix,
+                Paint(Paint.FILTER_BITMAP_FLAG),
+            )
+        }
+        return output
+    }
+
+    private fun enhanceContrast(bitmap: Bitmap): Bitmap {
+        val contrast = 2.5f
+        val translate = (-0.5f * contrast + 0.5f) * 255f
+        val colorMatrix =
+            ColorMatrix(
+                floatArrayOf(
+                    contrast,
+                    0f,
+                    0f,
+                    0f,
+                    translate,
+                    0f,
+                    contrast,
+                    0f,
+                    0f,
+                    translate,
+                    0f,
+                    0f,
+                    contrast,
+                    0f,
+                    translate,
+                    0f,
+                    0f,
+                    0f,
+                    1f,
+                    0f,
+                ),
+            )
+        val output = Bitmap.createBitmap(bitmap.width, bitmap.height, Bitmap.Config.ARGB_8888)
+        Canvas(output).drawBitmap(
+            bitmap,
+            0f,
+            0f,
+            Paint(Paint.FILTER_BITMAP_FLAG).apply {
+                colorFilter = ColorMatrixColorFilter(colorMatrix)
+            },
+        )
+        return output
+    }
+
+    private fun distance(
+        points: FloatArray,
+        startIndex: Int,
+        endIndex: Int,
+    ): Float =
+        hypot(
+            points[startIndex] - points[endIndex],
+            points[startIndex + 1] - points[endIndex + 1],
+        )
 }

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/ImageScanner.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/ImageScanner.kt
@@ -15,39 +15,6 @@ import kotlin.math.hypot
 import kotlin.math.max
 
 object ImageScanner {
-    private val barcodeReaders =
-        listOf(
-            BarcodeReader(
-                BarcodeReader.Options(
-                    tryHarder = true,
-                    tryRotate = true,
-                    tryInvert = true,
-                ),
-            ),
-            BarcodeReader(
-                BarcodeReader.Options(
-                    tryHarder = true,
-                    tryRotate = true,
-                    tryInvert = true,
-                    tryDenoise = true,
-                    tryDownscale = false,
-                    binarizer = BarcodeReader.Binarizer.GLOBAL_HISTOGRAM,
-                ),
-            ),
-        )
-
-    private val symbolLocator =
-        BarcodeReader(
-            BarcodeReader.Options(
-                tryHarder = true,
-                tryRotate = true,
-                tryInvert = true,
-                tryDenoise = true,
-                tryDownscale = false,
-                returnErrors = true,
-            ),
-        )
-
     data class ScanResult(
         val text: String,
         val format: String,
@@ -70,7 +37,8 @@ object ImageScanner {
         scanBitmap(bitmap)?.let { return it }
 
         val locatedResult =
-            symbolLocator
+            BarcodeReaders
+                .symbolLocator
                 .read(bitmap)
                 .firstOrNull()
                 ?: return null
@@ -84,10 +52,10 @@ object ImageScanner {
     }
 
     private fun scanBitmap(bitmap: Bitmap): ScanResult? {
-        barcodeReaders.forEachIndexed { index, reader ->
+        BarcodeReaders.decoders.forEach { reader ->
             val results = reader.read(bitmap)
-            val result = results.firstOrNull { it.error == null } ?: return@forEachIndexed
-            val text = result.text?.takeIf { it.isNotBlank() } ?: return@forEachIndexed
+            val result = results.firstOrNull { it.error == null } ?: return@forEach
+            val text = result.text?.takeIf { it.isNotBlank() } ?: return@forEach
             return ScanResult(
                 text = text,
                 format = result.format.name,

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/ImageScanner.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/ImageScanner.kt
@@ -2,17 +2,8 @@ package nz.eloque.foss_wallet.ui.screens.create
 
 import android.content.ContentResolver
 import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.ColorMatrix
-import android.graphics.ColorMatrixColorFilter
 import android.graphics.ImageDecoder
-import android.graphics.Matrix
-import android.graphics.Paint
 import android.net.Uri
-import zxingcpp.BarcodeReader
-import kotlin.math.hypot
-import kotlin.math.max
 
 object ImageScanner {
     data class ScanResult(
@@ -34,176 +25,11 @@ object ImageScanner {
     }
 
     fun scanFrom(bitmap: Bitmap): ScanResult? {
-        scanBitmap(bitmap)?.let { return it }
-
-        val locatedResult =
-            BarcodeReaders
-                .symbolLocator
-                .read(bitmap)
-                .firstOrNull()
-                ?: return null
-        val position = locatedResult.position
-
-        for (correctedBitmap in perspectiveCorrectionCandidates(bitmap, position)) {
-            scanBitmap(correctedBitmap)?.let { return it }
-        }
-
-        return null
-    }
-
-    private fun scanBitmap(bitmap: Bitmap): ScanResult? {
-        BarcodeReaders.decoders.forEach { reader ->
-            val results = reader.read(bitmap)
-            val result = results.firstOrNull { it.error == null } ?: return@forEach
-            val text = result.text?.takeIf { it.isNotBlank() } ?: return@forEach
-            return ScanResult(
-                text = text,
-                format = result.format.name,
-            )
-        }
-
-        return null
-    }
-
-    private fun perspectiveCorrectionCandidates(
-        bitmap: Bitmap,
-        position: BarcodeReader.Position,
-    ): List<Bitmap> {
-        val points =
-            floatArrayOf(
-                position.topLeft.x.toFloat(),
-                position.topLeft.y.toFloat(),
-                position.topRight.x.toFloat(),
-                position.topRight.y.toFloat(),
-                position.bottomRight.x.toFloat(),
-                position.bottomRight.y.toFloat(),
-                position.bottomLeft.x.toFloat(),
-                position.bottomLeft.y.toFloat(),
-            )
-
-        return listOf(1.35f, 1.8f)
-            .flatMap { scale ->
-                val expandedPoints = expandAroundCenter(points, scale)
-                val corrected = perspectiveCorrect(bitmap, expandedPoints)
-                listOf(corrected, enhanceContrast(corrected))
-            }
-    }
-
-    private fun expandAroundCenter(
-        points: FloatArray,
-        scale: Float,
-    ): FloatArray {
-        var centerX = 0f
-        var centerY = 0f
-        for (index in points.indices step 2) {
-            centerX += points[index]
-            centerY += points[index + 1]
-        }
-        centerX /= 4f
-        centerY /= 4f
-
-        return FloatArray(points.size) { index ->
-            val center = if (index % 2 == 0) centerX else centerY
-            center + (points[index] - center) * scale
-        }
-    }
-
-    private fun perspectiveCorrect(
-        bitmap: Bitmap,
-        sourcePoints: FloatArray,
-    ): Bitmap {
-        val width =
-            max(
-                distance(sourcePoints, 0, 2),
-                distance(sourcePoints, 6, 4),
-            ).toInt()
-        val height =
-            max(
-                distance(sourcePoints, 0, 6),
-                distance(sourcePoints, 2, 4),
-            ).toInt()
-        val margin = max(24, height / 4)
-
-        val destinationPoints =
-            floatArrayOf(
-                margin.toFloat(),
-                margin.toFloat(),
-                (width + margin).toFloat(),
-                margin.toFloat(),
-                (width + margin).toFloat(),
-                (height + margin).toFloat(),
-                margin.toFloat(),
-                (height + margin).toFloat(),
-            )
-
-        val matrix =
-            Matrix().apply {
-                setPolyToPoly(sourcePoints, 0, destinationPoints, 0, 4)
-            }
-        val output =
-            Bitmap.createBitmap(
-                width + margin * 2,
-                height + margin * 2,
-                Bitmap.Config.ARGB_8888,
-            )
-        Canvas(output).apply {
-            drawColor(Color.WHITE)
-            drawBitmap(
-                bitmap,
-                matrix,
-                Paint(Paint.FILTER_BITMAP_FLAG),
-            )
-        }
-        return output
-    }
-
-    private fun enhanceContrast(bitmap: Bitmap): Bitmap {
-        val contrast = 2.5f
-        val translate = (-0.5f * contrast + 0.5f) * 255f
-        val colorMatrix =
-            ColorMatrix(
-                floatArrayOf(
-                    contrast,
-                    0f,
-                    0f,
-                    0f,
-                    translate,
-                    0f,
-                    contrast,
-                    0f,
-                    0f,
-                    translate,
-                    0f,
-                    0f,
-                    contrast,
-                    0f,
-                    translate,
-                    0f,
-                    0f,
-                    0f,
-                    1f,
-                    0f,
-                ),
-            )
-        val output = Bitmap.createBitmap(bitmap.width, bitmap.height, Bitmap.Config.ARGB_8888)
-        Canvas(output).drawBitmap(
-            bitmap,
-            0f,
-            0f,
-            Paint(Paint.FILTER_BITMAP_FLAG).apply {
-                colorFilter = ColorMatrixColorFilter(colorMatrix)
-            },
+        val result = BarcodeReaders.primary.read(bitmap).firstOrNull() ?: return null
+        val text = result.text?.takeIf { it.isNotBlank() } ?: return null
+        return ScanResult(
+            text = text,
+            format = result.format.name,
         )
-        return output
     }
-
-    private fun distance(
-        points: FloatArray,
-        startIndex: Int,
-        endIndex: Int,
-    ): Float =
-        hypot(
-            points[startIndex] - points[endIndex],
-            points[startIndex + 1] - points[endIndex + 1],
-        )
 }

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/ImageScanner.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/ImageScanner.kt
@@ -69,12 +69,12 @@ object ImageScanner {
     fun scanFrom(bitmap: Bitmap): ScanResult? {
         scanBitmap(bitmap)?.let { return it }
 
-        val position =
+        val locatedResult =
             symbolLocator
                 .read(bitmap)
                 .firstOrNull()
-                ?.position
                 ?: return null
+        val position = locatedResult.position
 
         for (correctedBitmap in perspectiveCorrectionCandidates(bitmap, position)) {
             scanBitmap(correctedBitmap)?.let { return it }
@@ -84,17 +84,17 @@ object ImageScanner {
     }
 
     private fun scanBitmap(bitmap: Bitmap): ScanResult? {
-        val result =
-            barcodeReaders
-                .asSequence()
-                .flatMap { it.read(bitmap).asSequence() }
-                .firstOrNull { it.error == null }
-                ?: return null
-        val text = result.text?.takeIf { it.isNotBlank() } ?: return null
-        return ScanResult(
-            text = text,
-            format = result.format.name,
-        )
+        barcodeReaders.forEachIndexed { index, reader ->
+            val results = reader.read(bitmap)
+            val result = results.firstOrNull { it.error == null } ?: return@forEachIndexed
+            val text = result.text?.takeIf { it.isNotBlank() } ?: return@forEachIndexed
+            return ScanResult(
+                text = text,
+                format = result.format.name,
+            )
+        }
+
+        return null
     }
 
     private fun perspectiveCorrectionCandidates(

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/ScanActivity.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/ScanActivity.kt
@@ -80,38 +80,6 @@ class ScanActivity : AppCompatActivity() {
     private var isCameraBound = false
     private var analyzedFrameCount = 0
     private val cameraExecutor = Executors.newSingleThreadExecutor()
-    private val barcodeReaders =
-        listOf(
-            BarcodeReader(
-                BarcodeReader.Options(
-                    tryHarder = true,
-                    tryRotate = true,
-                    tryInvert = true,
-                ),
-            ),
-            BarcodeReader(
-                BarcodeReader.Options(
-                    tryHarder = true,
-                    tryRotate = true,
-                    tryInvert = true,
-                    tryDenoise = true,
-                    tryDownscale = false,
-                    binarizer = BarcodeReader.Binarizer.GLOBAL_HISTOGRAM,
-                ),
-            ),
-        )
-    private val symbolLocator =
-        BarcodeReader(
-            BarcodeReader.Options(
-                tryHarder = true,
-                tryRotate = true,
-                tryInvert = true,
-                tryDenoise = true,
-                tryDownscale = false,
-                returnErrors = true,
-            ),
-        )
-
     private val pickImageLauncher =
         registerForActivityResult(ActivityResultContracts.GetContent()) { uri ->
             val pickedUri = uri ?: return@registerForActivityResult
@@ -232,7 +200,8 @@ class ScanActivity : AppCompatActivity() {
                     image.use {
                         analyzedFrameCount += 1
                         val decodedResult =
-                            barcodeReaders
+                            BarcodeReaders
+                                .decoders
                                 .asSequence()
                                 .flatMap { reader -> reader.read(it).asSequence() }
                                 .firstOrNull { result -> result.error == null && !result.text.isNullOrBlank() }
@@ -240,7 +209,7 @@ class ScanActivity : AppCompatActivity() {
 
                         if (analyzedFrameCount % 8 != 0) return@use CameraScanResult.NoFeedbackChange
 
-                        val locatedResult = symbolLocator.read(it).firstOrNull()
+                        val locatedResult = BarcodeReaders.symbolLocator.read(it).firstOrNull()
                         if (locatedResult != null) CameraScanResult.SymbolLocated else CameraScanResult.NoSymbol
                     }
                 } catch (_: RuntimeException) {

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/ScanActivity.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/ScanActivity.kt
@@ -13,6 +13,8 @@ import androidx.camera.core.Camera
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.Preview
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.Canvas
@@ -70,18 +72,43 @@ class ScanActivity : AppCompatActivity() {
     private var previewView: PreviewView? = null
     private var cameraPermissionState by mutableStateOf(CameraPermissionState.Requesting)
     private var isTorchEnabled by mutableStateOf(false)
+    private var scannerFeedback by mutableStateOf(ScannerFeedback.None)
     private var lensFacing by mutableIntStateOf(CameraSelector.LENS_FACING_BACK)
     private var hasDeliveredResult = false
     private var cameraProvider: ProcessCameraProvider? = null
     private var boundCamera: Camera? = null
     private var isCameraBound = false
+    private var analyzedFrameCount = 0
     private val cameraExecutor = Executors.newSingleThreadExecutor()
-    private val barcodeReader =
+    private val barcodeReaders =
+        listOf(
+            BarcodeReader(
+                BarcodeReader.Options(
+                    tryHarder = true,
+                    tryRotate = true,
+                    tryInvert = true,
+                ),
+            ),
+            BarcodeReader(
+                BarcodeReader.Options(
+                    tryHarder = true,
+                    tryRotate = true,
+                    tryInvert = true,
+                    tryDenoise = true,
+                    tryDownscale = false,
+                    binarizer = BarcodeReader.Binarizer.GLOBAL_HISTOGRAM,
+                ),
+            ),
+        )
+    private val symbolLocator =
         BarcodeReader(
             BarcodeReader.Options(
                 tryHarder = true,
                 tryRotate = true,
                 tryInvert = true,
+                tryDenoise = true,
+                tryDownscale = false,
+                returnErrors = true,
             ),
         )
 
@@ -126,6 +153,7 @@ class ScanActivity : AppCompatActivity() {
                 QrScannerContent(
                     permissionState = cameraPermissionState,
                     isTorchEnabled = isTorchEnabled,
+                    scannerFeedback = scannerFeedback,
                     onPreviewReady = { view ->
                         previewView = view
                         if (cameraPermissionState == CameraPermissionState.Granted) {
@@ -179,9 +207,17 @@ class ScanActivity : AppCompatActivity() {
                 it.surfaceProvider = boundPreviewView.surfaceProvider
             }
 
+        val resolutionSelector =
+            ResolutionSelector
+                .Builder()
+                .setAllowedResolutionMode(ResolutionSelector.PREFER_HIGHER_RESOLUTION_OVER_CAPTURE_RATE)
+                .setResolutionStrategy(ResolutionStrategy.HIGHEST_AVAILABLE_STRATEGY)
+                .build()
+
         val analyzer =
             ImageAnalysis
                 .Builder()
+                .setResolutionSelector(resolutionSelector)
                 .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
                 .build()
 
@@ -191,14 +227,43 @@ class ScanActivity : AppCompatActivity() {
                 return@setAnalyzer
             }
 
-            // Prevent crashes due to failing barcode reader
-            val result =
+            val scanResult =
                 try {
-                    image.use { barcodeReader.read(it).firstOrNull() }
+                    image.use {
+                        analyzedFrameCount += 1
+                        val decodedResult =
+                            barcodeReaders
+                                .asSequence()
+                                .flatMap { reader -> reader.read(it).asSequence() }
+                                .firstOrNull { result -> result.error == null && !result.text.isNullOrBlank() }
+                        if (decodedResult != null) return@use CameraScanResult.Decoded(decodedResult)
+
+                        if (analyzedFrameCount % 8 != 0) return@use CameraScanResult.NoFeedbackChange
+
+                        val locatedResult = symbolLocator.read(it).firstOrNull()
+                        if (locatedResult != null) CameraScanResult.SymbolLocated else CameraScanResult.NoSymbol
+                    }
                 } catch (_: RuntimeException) {
                     return@setAnalyzer
                 }
-            val text = result?.text?.takeIf { it.isNotBlank() } ?: return@setAnalyzer
+
+            if (scanResult == CameraScanResult.SymbolLocated && scannerFeedback != ScannerFeedback.SymbolLocated) {
+                runOnUiThread {
+                    scannerFeedback = ScannerFeedback.SymbolLocated
+                }
+                return@setAnalyzer
+            }
+
+            if (scanResult == CameraScanResult.NoSymbol && scannerFeedback != ScannerFeedback.None) {
+                runOnUiThread {
+                    scannerFeedback = ScannerFeedback.None
+                }
+                return@setAnalyzer
+            }
+
+            val result = (scanResult as? CameraScanResult.Decoded)?.result ?: return@setAnalyzer
+            val text = result.text!!.takeIf { it.isNotBlank() } ?: return@setAnalyzer
+
             // Prevent crashes due to unsupported formats in zxing
             val format =
                 try {
@@ -297,10 +362,28 @@ private enum class CameraPermissionState {
     Denied,
 }
 
+private enum class ScannerFeedback {
+    None,
+    SymbolLocated,
+}
+
+private sealed class CameraScanResult {
+    data object NoFeedbackChange : CameraScanResult()
+
+    data object NoSymbol : CameraScanResult()
+
+    data object SymbolLocated : CameraScanResult()
+
+    data class Decoded(
+        val result: BarcodeReader.Result,
+    ) : CameraScanResult()
+}
+
 @Composable
 private fun QrScannerContent(
     permissionState: CameraPermissionState,
     isTorchEnabled: Boolean,
+    scannerFeedback: ScannerFeedback,
     onPreviewReady: (PreviewView) -> Unit,
     onRequestCameraPermission: () -> Unit,
     onOpenGallery: () -> Unit,
@@ -322,6 +405,13 @@ private fun QrScannerContent(
                 )
 
                 ScannerOverlay(modifier = Modifier.fillMaxSize())
+                ScannerFeedbackChip(
+                    scannerFeedback = scannerFeedback,
+                    modifier =
+                        Modifier
+                            .align(Alignment.TopCenter)
+                            .padding(top = 96.dp),
+                )
             }
 
             CameraPermissionState.Requesting,
@@ -419,6 +509,27 @@ private fun QrScannerContent(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun ScannerFeedbackChip(
+    scannerFeedback: ScannerFeedback,
+    modifier: Modifier = Modifier,
+) {
+    if (scannerFeedback == ScannerFeedback.None) return
+
+    Box(
+        modifier =
+            modifier
+                .clip(CircleShape)
+                .background(Color.White.copy(alpha = 0.92f))
+                .padding(horizontal = 16.dp, vertical = 10.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.barcode_detected_keep_steady),
+            color = Color.Black,
+        )
     }
 }
 

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/ScanActivity.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/ScanActivity.kt
@@ -65,6 +65,7 @@ import java.util.concurrent.Executors
 
 class ScanActivity : AppCompatActivity() {
     companion object {
+        private const val SCANNER_FEEDBACK_MIN_DURATION_MS = 1_000L
         const val EXTRA_RESULT = "scan_result"
         const val EXTRA_RESULT_FORMAT = "scan_result_format"
     }
@@ -79,6 +80,7 @@ class ScanActivity : AppCompatActivity() {
     private var boundCamera: Camera? = null
     private var isCameraBound = false
     private var analyzedFrameCount = 0
+    private var lastSymbolLocatedAt = 0L
     private val cameraExecutor = Executors.newSingleThreadExecutor()
     private val pickImageLauncher =
         registerForActivityResult(ActivityResultContracts.GetContent()) { uri ->
@@ -216,14 +218,20 @@ class ScanActivity : AppCompatActivity() {
                     return@setAnalyzer
                 }
 
-            if (scanResult == CameraScanResult.SymbolLocated && scannerFeedback != ScannerFeedback.SymbolLocated) {
+            if (scanResult == CameraScanResult.SymbolLocated) {
+                lastSymbolLocatedAt = System.currentTimeMillis()
+                if (scannerFeedback == ScannerFeedback.SymbolLocated) return@setAnalyzer
                 runOnUiThread {
                     scannerFeedback = ScannerFeedback.SymbolLocated
                 }
                 return@setAnalyzer
             }
 
-            if (scanResult == CameraScanResult.NoSymbol && scannerFeedback != ScannerFeedback.None) {
+            if (
+                scanResult == CameraScanResult.NoSymbol &&
+                scannerFeedback != ScannerFeedback.None &&
+                System.currentTimeMillis() - lastSymbolLocatedAt >= SCANNER_FEEDBACK_MIN_DURATION_MS
+            ) {
                 runOnUiThread {
                     scannerFeedback = ScannerFeedback.None
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,6 +103,7 @@
     <string name="barcode_value_invalid">The given value is not a valid %1$s code</string>
     <string name="help_translate">Help translate</string>
     <string name="choose_image">Choose image</string>
+    <string name="barcode_detected_keep_steady">Barcode detected, keep steady</string>
     <string name="clear_selection">Clear selection</string>
     <string name="select_all">Select all</string>
     <string name="add_tag">Add tag</string>


### PR DESCRIPTION
I recently traveled and encountered difficulties scanning PDF147 barcodes into the wallet app. I am attaching pictures of the respective barcodes to the thread. In this PR I make two main changes to the barcode scanning that were necessary to fix this issue:
- Add a "try harder" fallback for the scanner, using symbol location, binarization, denoising
- Increase the resolution of the image stream from the scanner. We don't really care so much about high frame rate I think.

I also added a pop-up to notify the user when a symbol has been located but could not get decoded quite yet.
On a related note it might be interesting to add a button to capture an image and then let loose a bunch of even harder-trying scanners.

<img width="400" height="600" alt="1b0c8a66-ff3b-4888-b068-dca4adc623bb" src="https://github.com/user-attachments/assets/0a59d679-44e1-4191-9817-d358cd265d95" />
<img width="400" height="600" alt="9d74a8ce-ca96-46ea-8bab-29e34bab3e93" src="https://github.com/user-attachments/assets/83327bf4-effd-440b-ab68-4fbd43ece242" />

