### PR TITLE
Fix back navigation for pass additions

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/WalletScaffold.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/WalletScaffold.kt
@@ -39,6 +39,7 @@ fun WalletScaffold(
     floatingActionButton: @Composable () -> Unit = {},
     bottomBar: @Composable () -> Unit = {},
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+    onNavigateBack: () -> Unit = { navController.popBackStack() },
     content: @Composable (scrollBehavior: TopAppBarScrollBehavior) -> Unit,
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
@@ -55,7 +56,7 @@ fun WalletScaffold(
                 },
                 navigationIcon = {
                     if (toolWindow) {
-                        IconButton(onClick = { navController.popBackStack() }) {
+                        IconButton(onClick = onNavigateBack) {
                             Icon(imageVector = Icons.AutoMirrored.Default.ArrowBack, contentDescription = stringResource(R.string.back))
                         }
                     }

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/FabMenu.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/FabMenu.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.ToggleFloatingActionButton
 import androidx.compose.material3.ToggleFloatingActionButtonDefaults.animateIcon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -32,9 +33,19 @@ data class FabMenuItem(
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun FabMenu(items: List<FabMenuItem>) {
+fun FabMenu(
+    items: List<FabMenuItem>,
+    openMenuRequest: Boolean = false,
+    onOpenMenuRequestConsumed: () -> Unit = {},
+) {
     Box {
         var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
+        LaunchedEffect(openMenuRequest) {
+            if (openMenuRequest) {
+                fabMenuExpanded = true
+                onOpenMenuRequestConsumed()
+            }
+        }
         BackHandler(fabMenuExpanded) { fabMenuExpanded = false }
         FloatingActionButtonMenu(
             modifier = Modifier.align(Alignment.BottomEnd),

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/AdvancedAddScreen.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/AdvancedAddScreen.kt
@@ -1,6 +1,7 @@
 package nz.eloque.foss_wallet.ui.screens.create
 
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -25,6 +26,7 @@ import nz.eloque.foss_wallet.R
 import nz.eloque.foss_wallet.model.BarCode
 import nz.eloque.foss_wallet.ui.Screen
 import nz.eloque.foss_wallet.ui.WalletScaffold
+import nz.eloque.foss_wallet.ui.screens.wallet.openWalletFabMenu
 import java.net.URLEncoder
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -35,10 +37,17 @@ fun AdvancedAddScreen(navController: NavHostController) {
     val clipboard = LocalClipboard.current
     val coroutineScope = rememberCoroutineScope()
 
+    BackHandler {
+        navController.openWalletFabMenu()
+    }
+
     WalletScaffold(
         navController = navController,
         toolWindow = true,
         title = stringResource(R.string.advanced),
+        onNavigateBack = {
+            navController.openWalletFabMenu()
+        },
     ) {
         Column(
             modifier =

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/scan/ScanLauncher.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/scan/ScanLauncher.kt
@@ -17,41 +17,50 @@ import nz.eloque.foss_wallet.ui.screens.create.ScanActivity
 
 object ScanLauncher {
     @Composable
-    fun launch(onScanned: (BarCode) -> Unit): ManagedActivityResultLauncher<Intent, ActivityResult> {
+    fun launch(
+        onCanceled: () -> Unit = {},
+        onScanned: (BarCode) -> Unit,
+    ): ManagedActivityResultLauncher<Intent, ActivityResult> {
         val context = LocalContext.current
         val resources = LocalResources.current
 
         return rememberLauncherForActivityResult(
             contract = ActivityResultContracts.StartActivityForResult(),
             onResult = { activityResult ->
-                if (activityResult.resultCode == Activity.RESULT_OK) {
-                    val resultData = activityResult.data
-                    val contents = resultData?.getStringExtra(ScanActivity.EXTRA_RESULT)
-                    if (contents != null) {
-                        val formatName = resultData.getStringExtra(ScanActivity.EXTRA_RESULT_FORMAT)
-
-                        val scannedFormat =
-                            try {
-                                BarcodeFormat.valueOf(formatName ?: BarcodeFormat.QR_CODE.name)
-                            } catch (_: IllegalArgumentException) {
-                                Toast
-                                    .makeText(
-                                        context,
-                                        resources.getString(R.string.no_barcode_format_given),
-                                        Toast.LENGTH_SHORT,
-                                    ).show()
-                                BarcodeFormat.QR_CODE
-                            }
-                        val barcode =
-                            BarCode(
-                                message = contents,
-                                altText = contents,
-                                format = scannedFormat,
-                                encoding = Charsets.UTF_8,
-                            )
-                        onScanned(barcode)
-                    }
+                if (activityResult.resultCode != Activity.RESULT_OK) {
+                    onCanceled()
+                    return@rememberLauncherForActivityResult
                 }
+
+                val resultData = activityResult.data
+                val contents = resultData?.getStringExtra(ScanActivity.EXTRA_RESULT)
+                if (contents == null) {
+                    onCanceled()
+                    return@rememberLauncherForActivityResult
+                }
+
+                val formatName = resultData.getStringExtra(ScanActivity.EXTRA_RESULT_FORMAT)
+
+                val scannedFormat =
+                    try {
+                        BarcodeFormat.valueOf(formatName ?: BarcodeFormat.QR_CODE.name)
+                    } catch (_: IllegalArgumentException) {
+                        Toast
+                            .makeText(
+                                context,
+                                resources.getString(R.string.no_barcode_format_given),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                        BarcodeFormat.QR_CODE
+                    }
+                val barcode =
+                    BarCode(
+                        message = contents,
+                        altText = contents,
+                        format = scannedFormat,
+                        encoding = Charsets.UTF_8,
+                    )
+                onScanned(barcode)
             },
         )
     }

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/scan/ScanView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/scan/ScanView.kt
@@ -31,7 +31,7 @@ import nz.eloque.foss_wallet.persistence.BarcodePosition
 import nz.eloque.foss_wallet.ui.Screen
 import nz.eloque.foss_wallet.ui.screens.create.ScanActivity
 import nz.eloque.foss_wallet.ui.screens.pass.BarcodesView
-import nz.eloque.foss_wallet.ui.screens.wallet.OPEN_FAB_MENU_REQUEST
+import nz.eloque.foss_wallet.ui.screens.wallet.openWalletFabMenu
 import java.net.URLEncoder
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -51,8 +51,7 @@ fun ScanView(
                 scannedBarcode = it
             },
             onCanceled = {
-                navController.getBackStackEntry(Screen.Wallet.route).savedStateHandle[OPEN_FAB_MENU_REQUEST] = true
-                navController.popBackStack(Screen.Wallet.route, inclusive = false)
+                navController.openWalletFabMenu()
             },
         )
 

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/scan/ScanView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/scan/ScanView.kt
@@ -31,6 +31,7 @@ import nz.eloque.foss_wallet.persistence.BarcodePosition
 import nz.eloque.foss_wallet.ui.Screen
 import nz.eloque.foss_wallet.ui.screens.create.ScanActivity
 import nz.eloque.foss_wallet.ui.screens.pass.BarcodesView
+import nz.eloque.foss_wallet.ui.screens.wallet.OPEN_FAB_MENU_REQUEST
 import java.net.URLEncoder
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -45,9 +46,15 @@ fun ScanView(
     var initialScanHandled by remember { mutableStateOf(false) }
 
     val scanLauncher =
-        ScanLauncher.launch {
-            scannedBarcode = it
-        }
+        ScanLauncher.launch(
+            onScanned = {
+                scannedBarcode = it
+            },
+            onCanceled = {
+                navController.getBackStackEntry(Screen.Wallet.route).savedStateHandle[OPEN_FAB_MENU_REQUEST] = true
+                navController.popBackStack(Screen.Wallet.route, inclusive = false)
+            },
+        )
 
     LaunchedEffect(initialScanHandled) {
         if (!initialScanHandled) {

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletNavigation.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletNavigation.kt
@@ -1,0 +1,11 @@
+package nz.eloque.foss_wallet.ui.screens.wallet
+
+import androidx.navigation.NavController
+import nz.eloque.foss_wallet.ui.Screen
+
+const val OPEN_FAB_MENU_REQUEST = "open_fab_menu_request"
+
+fun NavController.openWalletFabMenu() {
+    getBackStackEntry(Screen.Wallet.route).savedStateHandle[OPEN_FAB_MENU_REQUEST] = true
+    popBackStack(Screen.Wallet.route, inclusive = false)
+}

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletScreen.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
@@ -39,6 +40,8 @@ import nz.eloque.foss_wallet.ui.WalletScaffold
 import nz.eloque.foss_wallet.ui.components.FabMenu
 import nz.eloque.foss_wallet.ui.components.FabMenuItem
 import nz.eloque.foss_wallet.utils.PkpassMimeTypes
+
+const val OPEN_FAB_MENU_REQUEST = "open_fab_menu_request"
 
 @SuppressLint("LocalContextGetResourceValueCall")
 @OptIn(ExperimentalMaterial3Api::class)
@@ -86,6 +89,12 @@ fun WalletScreen(
     val selectedPasses = remember { mutableStateSetOf<LocalizedPassWithTags>() }
     val visiblePasses = remember { mutableStateOf<Set<LocalizedPassWithTags>>(emptySet()) }
     val allVisibleSelected = visiblePasses.value.isNotEmpty() && visiblePasses.value.all { selectedPasses.contains(it) }
+    val savedStateHandle = navController.currentBackStackEntry?.savedStateHandle
+    val openFabMenuRequest =
+        savedStateHandle
+            ?.getStateFlow(OPEN_FAB_MENU_REQUEST, false)
+            ?.collectAsState()
+            ?.value == true
 
     WalletScaffold(
         navController = navController,
@@ -140,6 +149,10 @@ fun WalletScreen(
                 )
             } else {
                 FabMenu(
+                    openMenuRequest = openFabMenuRequest,
+                    onOpenMenuRequestConsumed = {
+                        savedStateHandle?.set(OPEN_FAB_MENU_REQUEST, false)
+                    },
                     items =
                         listOf(
                             FabMenuItem(

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletScreen.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletScreen.kt
@@ -41,8 +41,6 @@ import nz.eloque.foss_wallet.ui.components.FabMenu
 import nz.eloque.foss_wallet.ui.components.FabMenuItem
 import nz.eloque.foss_wallet.utils.PkpassMimeTypes
 
-const val OPEN_FAB_MENU_REQUEST = "open_fab_menu_request"
-
 @SuppressLint("LocalContextGetResourceValueCall")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -61,6 +59,11 @@ fun WalletScreen(
     val launcher =
         rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
             println("selected file URI $uris")
+            if (uris.isEmpty()) {
+                navController.currentBackStackEntry?.savedStateHandle?.set(OPEN_FAB_MENU_REQUEST, true)
+                return@rememberLauncherForActivityResult
+            }
+
             coroutineScope.launch {
                 loading.value = true
                 withContext(Dispatchers.IO) {


### PR DESCRIPTION
When clicking "back" on the Scan Barcode view, one would end up at an empty "Create Pass" screen. This fixes that by navigating back to the main wallet view. At the same time, this PR consistently opens the FAB menu when navigating back from barcode, advanced or import views.

[untitled.webm](https://github.com/user-attachments/assets/7b38c388-c35c-4dc5-91d4-da66a80bac7a)
