### PR TITLE
Improve the pager indicator

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/GroupCard.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/GroupCard.kt
@@ -1,6 +1,5 @@
 package nz.eloque.foss_wallet.ui.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -8,10 +7,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.FolderDelete
@@ -23,15 +20,12 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -105,7 +99,11 @@ fun GroupCard(
                         .fillMaxWidth()
                         .height(56.dp),
             ) {
-                SelectionIndicator(pagerState.currentPage, passes.size, Modifier.align(Alignment.Center))
+                HorizontalPagerIndicator(
+                    pagerState = pagerState,
+                    modifier = Modifier.align(Alignment.Center),
+                )
+
                 Row(
                     modifier = Modifier.align(Alignment.CenterEnd),
                 ) {
@@ -161,31 +159,6 @@ fun GroupCard(
                     }
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun SelectionIndicator(
-    selectedItem: Int,
-    itemCount: Int,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier,
-    ) {
-        repeat(itemCount) { index ->
-            val isSelected = index == selectedItem
-            Box(
-                modifier =
-                    Modifier
-                        .padding(4.dp)
-                        .size(if (isSelected) 10.dp else 8.dp)
-                        .clip(CircleShape)
-                        .background(if (isSelected) MaterialTheme.colorScheme.primary else Color.Gray.copy(alpha = 0.4f)),
-            )
         }
     }
 }

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/HorizontalPagerIndicator.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/HorizontalPagerIndicator.kt
@@ -1,0 +1,111 @@
+package nz.eloque.foss_wallet.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import nz.eloque.foss_wallet.ui.theme.WalletTheme
+
+@Composable
+fun HorizontalPagerIndicator(
+    pagerState: PagerState,
+    modifier: Modifier = Modifier,
+    maxItems: Int = 7,
+    indicatorSize: Dp = 8.dp,
+    spacing: Dp = 8.dp,
+    activeColor: Color = MaterialTheme.colorScheme.primary,
+    inactiveColor: Color = MaterialTheme.colorScheme.secondaryContainer,
+) {
+    val maxItems = (if (maxItems % 2 == 0) maxItems - 1 else maxItems).coerceAtLeast(3).coerceAtMost(pagerState.pageCount)
+
+    val pageOffsetFraction by remember { derivedStateOf { pagerState.currentPage + pagerState.currentPageOffsetFraction } }
+    val scrollOffsetFraction = (pageOffsetFraction - (maxItems / 2)).coerceIn(0f, (pagerState.pageCount - maxItems).toFloat())
+
+    Canvas(modifier.size(width = (indicatorSize + spacing) * (maxItems + 2) - spacing + indicatorSize, height = indicatorSize)) {
+        val indicatorSizePx = indicatorSize.toPx()
+        val spacingPx = spacing.toPx()
+
+        val firstVisibleItem = (pagerState.currentPage - maxItems / 2).coerceIn(0, pagerState.pageCount - maxItems) - 1
+        val lastVisibleItem = firstVisibleItem + maxItems + 1
+        (firstVisibleItem..lastVisibleItem).forEach {
+            val activeWidthFraction =
+                when (it - pageOffsetFraction.toInt()) {
+                    0 -> 1 - (pageOffsetFraction % 1)
+                    1 -> pageOffsetFraction % 1
+                    else -> 0f
+                }
+            val activeWidthTranslation = if (it > pageOffsetFraction.toInt()) indicatorSizePx * (1 - activeWidthFraction) else 0f
+
+            val isFirstPage = it == 0
+            val isLastPage = it == pagerState.pageCount - 1
+            val scale =
+                when (it - scrollOffsetFraction.toInt()) {
+                    maxItems -> (scrollOffsetFraction % 1) / if (isLastPage) 1 else 2
+                    maxItems - 1 -> if (isLastPage) 1f else 0.5f + (scrollOffsetFraction % 1) / 2
+                    1 -> 1 - (scrollOffsetFraction % 1) / 2
+                    0 -> (1 - scrollOffsetFraction % 1) / if (isFirstPage) 1 else 2
+                    -1, maxItems + 1 -> 0f
+                    else -> 1f
+                }
+
+            withTransform({
+                if (this@Canvas.layoutDirection == LayoutDirection.Rtl) scale(scaleX = -1f, scaleY = 1f)
+                translate(left = (indicatorSizePx + spacingPx) * (it + 1 - scrollOffsetFraction) + activeWidthTranslation)
+                scale(scaleX = scale, scaleY = scale, pivot = Offset(indicatorSizePx / 2, indicatorSizePx / 2))
+            }) {
+                drawRoundRect(
+                    color = if (it == pagerState.currentPage) activeColor else inactiveColor,
+                    size = Size(indicatorSizePx * (1 + activeWidthFraction), indicatorSizePx),
+                    cornerRadius = CornerRadius(indicatorSizePx / 2),
+                )
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun HorizontalPagerIndicatorPreview() {
+    WalletTheme {
+        Column(
+            modifier = Modifier.background(MaterialTheme.colorScheme.surface).padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            val pagerState = rememberPagerState { 10 }
+
+            HorizontalPager(
+                state = pagerState,
+                pageSpacing = 16.dp,
+            ) {
+                Box(Modifier.fillMaxWidth().height(100.dp).background(MaterialTheme.colorScheme.surfaceContainerHighest))
+            }
+
+            HorizontalPagerIndicator(pagerState)
+        }
+    }
+}

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/pass/PassViewComponents.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/pass/PassViewComponents.kt
@@ -6,14 +6,11 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -45,6 +42,7 @@ import nz.eloque.foss_wallet.persistence.BarcodePosition
 import nz.eloque.foss_wallet.ui.card.PassField
 import nz.eloque.foss_wallet.ui.components.AbbreviatingText
 import nz.eloque.foss_wallet.ui.components.FullscreenDialog
+import nz.eloque.foss_wallet.ui.components.HorizontalPagerIndicator
 import nz.eloque.foss_wallet.ui.effects.UpdateBrightness
 import java.io.File
 
@@ -82,9 +80,10 @@ fun Barcodes(
         }
 
         if (barcodes.size > 1) {
-            BarcodePagerIndicator(
-                selectedItem = pagerState.currentPage,
-                itemCount = barcodes.size,
+            HorizontalPagerIndicator(
+                pagerState = pagerState,
+                activeColor = LocalContentColor.current,
+                inactiveColor = LocalContentColor.current.copy(alpha = 0.3f),
             )
         }
     }
@@ -174,30 +173,6 @@ private fun BrokenBarcodeWarning() {
         modifier = Modifier.padding(48.dp).size(48.dp),
         tint = Color.Red,
     )
-}
-
-@Composable
-private fun BarcodePagerIndicator(
-    selectedItem: Int,
-    itemCount: Int,
-) {
-    Row(
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        repeat(itemCount) { index ->
-            val isSelected = index == selectedItem
-            Box(
-                modifier =
-                    Modifier
-                        .padding(4.dp)
-                        .width(if (isSelected) 14.dp else 8.dp)
-                        .height(8.dp)
-                        .clip(RoundedCornerShape(6.dp))
-                        .background(if (isSelected) LocalContentColor.current else LocalContentColor.current.copy(alpha = 0.3f)),
-            )
-        }
-    }
 }
 
 @Composable


### PR DESCRIPTION
This adds animations to the indicator row and limits the number of dots to an upper limit to prevent an overflow of the row. In such a case, the last and/or first visible dot is scaled to 50% of the normal size to indicate that the row continues in this direction. The default colors are identical to the ones used by e.g. the slider composable.

In total, `maxItems` dots plus two additional dots are drawn, with the first and the last one not visible in a settle state. The two additional dots are necessarry for the animations to work properly.