### PR TITLE
Improve the swipe to dismiss behavior

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/GroupCard.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/GroupCard.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -60,7 +61,6 @@ fun GroupCard(
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(5.dp),
-            modifier = Modifier.padding(10.dp),
         ) {
             val pagerState =
                 rememberPagerState(
@@ -69,6 +69,7 @@ fun GroupCard(
                 )
             HorizontalPager(
                 state = pagerState,
+                contentPadding = PaddingValues(10.dp),
                 pageSpacing = 28.dp,
             ) { index ->
                 val item = passes[index]

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/components/SwipeToDismiss.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/components/SwipeToDismiss.kt
@@ -1,6 +1,5 @@
 package nz.eloque.foss_wallet.ui.components
 
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -8,13 +7,14 @@ import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 
 @Composable
 fun SwipeToDismiss(
@@ -29,6 +29,7 @@ fun SwipeToDismiss(
 ) {
     val hapticFeedback = LocalHapticFeedback.current
     val swipeState = rememberSwipeToDismissBoxState()
+    val coroutineScope = rememberCoroutineScope()
 
     val (background, alignment) =
         when (swipeState.dismissDirection) {
@@ -38,7 +39,7 @@ fun SwipeToDismiss(
         }
 
     SwipeToDismissBox(
-        modifier = Modifier.animateContentSize(),
+        modifier = modifier,
         state = swipeState,
         enableDismissFromStartToEnd = allowRightSwipe,
         enableDismissFromEndToStart = allowLeftSwipe,
@@ -50,32 +51,12 @@ fun SwipeToDismiss(
                 background()
             }
         },
+        onDismiss = { dismissDirection ->
+            if (dismissDirection == SwipeToDismissBoxValue.StartToEnd) onRightSwipe() else onLeftSwipe()
+            coroutineScope.launch { swipeState.reset() }
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.GestureEnd)
+        },
     ) {
-        Box(
-            modifier = modifier,
-        ) {
-            content()
-        }
-    }
-
-    when (swipeState.currentValue) {
-        SwipeToDismissBoxValue.EndToStart -> {
-            LaunchedEffect(swipeState) {
-                onLeftSwipe()
-                swipeState.snapTo(SwipeToDismissBoxValue.Settled)
-                hapticFeedback.performHapticFeedback(HapticFeedbackType.GestureEnd)
-            }
-        }
-
-        SwipeToDismissBoxValue.StartToEnd -> {
-            LaunchedEffect(swipeState) {
-                onRightSwipe()
-                swipeState.snapTo(SwipeToDismissBoxValue.Settled)
-                hapticFeedback.performHapticFeedback(HapticFeedbackType.GestureEnd)
-            }
-        }
-
-        SwipeToDismissBoxValue.Settled -> {
-        }
+        content()
     }
 }

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletView.kt
@@ -169,7 +169,10 @@ fun WalletView(
                 selectedPasses = selectedPasses,
             )
         }
-        items(ungrouped) { pass ->
+        items(
+            items = ungrouped,
+            key = { it.pass.id },
+        ) { pass ->
             val isSelectionMode = selectedPasses.isNotEmpty()
             SwipeToDismiss(
                 leftSwipeBackground = {
@@ -182,7 +185,6 @@ fun WalletView(
                 allowRightSwipe = !isSelectionMode,
                 onLeftSwipe = { if (archive) walletViewModel.unarchive(pass.pass) else walletViewModel.archive(pass.pass) },
                 onRightSwipe = { passToDelete.value = pass },
-                modifier = Modifier.padding(2.dp),
             ) {
                 ShortPassCard(
                     pass = pass,


### PR DESCRIPTION
The usage of `Modifier.animateContentSize()` in `SwipeToDismiss()` clips the shadow of the pass card to its width which was avoided by adding a 2.dp padding to the pass card. But we do not need the modifier here as far as I can tell and we can remove it. This also has the benefit that the pass card is display all the way to the edge of the screen when swiping the card.

Instead of using a custom LaunchedEffect we can use the parameter `onDismiss` that is called when the action is settled. This means, that the pass card can be moved all the way to the left and than back to the initial position without archiving the pass. Apparently, the lazy column items need a unique key for this to work correctly. Otherwise all the following passes are archived as well.

The padding of a group card is replaced with a content padding of the horizontal pager to prevent a clipping of the shadow as well.