### PR TITLE
Spruce up insert function

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/persistence/pass/PassRepository.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/persistence/pass/PassRepository.kt
@@ -62,10 +62,10 @@ class PassRepository
             originalPass: OriginalPass?,
         ) {
             val id = pass.id
+            val metadata = passDao.metadata(id) ?: PassMetadata(id)
+
             passDao.insert(pass)
-            var passMetadata = passDao.metadata(id) ?: PassMetadata(pass.id)
-            passMetadata = passMetadata.copy(archived = AutoArchiver.shouldBeAutoArchived(pass, passMetadata))
-            passDao.insert(passMetadata)
+            passDao.insert(metadata.copy(archived = AutoArchiver.shouldBeAutoArchived(pass, metadata)))
             bitmaps.saveToDisk(context, id)
             originalPass?.saveToDisk(context, id)
         }

--- a/app/src/main/java/nz/eloque/foss_wallet/persistence/pass/PassRepository.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/persistence/pass/PassRepository.kt
@@ -63,9 +63,9 @@ class PassRepository
         ) {
             val id = pass.id
             val metadata = passDao.metadata(id) ?: PassMetadata(id)
-
+            val archived = AutoArchiver.shouldBeAutoArchived(pass, metadata)
             passDao.insert(pass)
-            passDao.insert(metadata.copy(archived = AutoArchiver.shouldBeAutoArchived(pass, metadata)))
+            passDao.insert(metadata.copy(archived = archived))
             bitmaps.saveToDisk(context, id)
             originalPass?.saveToDisk(context, id)
         }


### PR DESCRIPTION
Changes:
- Consistent use of “id”
- passMetadata -> metadata
- val archived was introduced
- The “var” was omitted by inlining .copy
- reordering

The behavior stays the same.