### PR TITLE
Save the background image when importing a pass

### DIFF
--- a/app/schemas/nz.eloque.foss_wallet.persistence.WalletDb/26.json
+++ b/app/schemas/nz.eloque.foss_wallet.persistence.WalletDb/26.json
@@ -1,0 +1,477 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 26,
+    "identityHash": "9b8302dac1a853d984d923bf8519420e",
+    "entities": [
+      {
+        "tableName": "Pass",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `description` TEXT NOT NULL, `formatVersion` INTEGER NOT NULL, `organization` TEXT NOT NULL, `serialNumber` TEXT NOT NULL, `type` TEXT NOT NULL, `barCodes` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `hasLogo` INTEGER NOT NULL, `hasStrip` INTEGER NOT NULL, `hasThumbnail` INTEGER NOT NULL, `hasFooter` INTEGER NOT NULL, `hasBackground` INTEGER NOT NULL DEFAULT 0, `deviceId` TEXT NOT NULL, `colors` TEXT, `relevantDates` TEXT NOT NULL, `expirationDate` TEXT, `logoText` TEXT, `authToken` TEXT, `webServiceUrl` TEXT, `passTypeIdentifier` TEXT, `locations` TEXT NOT NULL, `headerFields` TEXT NOT NULL, `primaryFields` TEXT NOT NULL, `secondaryFields` TEXT NOT NULL, `auxiliaryFields` TEXT NOT NULL, `backFields` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "formatVersion",
+            "columnName": "formatVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "organization",
+            "columnName": "organization",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "barCodes",
+            "columnName": "barCodes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasLogo",
+            "columnName": "hasLogo",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasStrip",
+            "columnName": "hasStrip",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasThumbnail",
+            "columnName": "hasThumbnail",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasFooter",
+            "columnName": "hasFooter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasBackground",
+            "columnName": "hasBackground",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colors",
+            "columnName": "colors",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "relevantDates",
+            "columnName": "relevantDates",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expirationDate",
+            "columnName": "expirationDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "logoText",
+            "columnName": "logoText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "authToken",
+            "columnName": "authToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "webServiceUrl",
+            "columnName": "webServiceUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "passTypeIdentifier",
+            "columnName": "passTypeIdentifier",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "locations",
+            "columnName": "locations",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "headerFields",
+            "columnName": "headerFields",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryFields",
+            "columnName": "primaryFields",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "secondaryFields",
+            "columnName": "secondaryFields",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "auxiliaryFields",
+            "columnName": "auxiliaryFields",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backFields",
+            "columnName": "backFields",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "PassMetadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`passId` TEXT NOT NULL, `groupId` INTEGER, `archived` INTEGER NOT NULL, `autoArchive` INTEGER NOT NULL, `renderLegacy` INTEGER NOT NULL, PRIMARY KEY(`passId`), FOREIGN KEY(`passId`) REFERENCES `Pass`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`groupId`) REFERENCES `PassGroup`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "passId",
+            "columnName": "passId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchive",
+            "columnName": "autoArchive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "renderLegacy",
+            "columnName": "renderLegacy",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "passId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_PassMetadata_passId",
+            "unique": false,
+            "columnNames": [
+              "passId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PassMetadata_passId` ON `${TABLE_NAME}` (`passId`)"
+          },
+          {
+            "name": "index_PassMetadata_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PassMetadata_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Pass",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "passId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "PassGroup",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "localization",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`passId` TEXT NOT NULL, `lang` TEXT NOT NULL, `label` TEXT NOT NULL, `text` TEXT NOT NULL, PRIMARY KEY(`passId`, `lang`, `label`), FOREIGN KEY(`passId`) REFERENCES `Pass`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "passId",
+            "columnName": "passId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "passId",
+            "lang",
+            "label"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "Pass",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "passId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "PassGroup",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`label` TEXT NOT NULL, `color` TEXT NOT NULL, PRIMARY KEY(`label`))",
+        "fields": [
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "label"
+          ]
+        }
+      },
+      {
+        "tableName": "PassTag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`passId` TEXT NOT NULL, `tagLabel` TEXT NOT NULL, PRIMARY KEY(`passId`, `tagLabel`), FOREIGN KEY(`passId`) REFERENCES `Pass`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tagLabel`) REFERENCES `tag`(`label`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "passId",
+            "columnName": "passId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagLabel",
+            "columnName": "tagLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "passId",
+            "tagLabel"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_PassTag_passId",
+            "unique": false,
+            "columnNames": [
+              "passId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PassTag_passId` ON `${TABLE_NAME}` (`passId`)"
+          },
+          {
+            "name": "index_PassTag_tagLabel",
+            "unique": false,
+            "columnNames": [
+              "tagLabel"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PassTag_tagLabel` ON `${TABLE_NAME}` (`tagLabel`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Pass",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "passId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tag",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tagLabel"
+            ],
+            "referencedColumns": [
+              "label"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Attachment",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fileName` TEXT NOT NULL, `passId` TEXT NOT NULL, PRIMARY KEY(`fileName`), FOREIGN KEY(`passId`) REFERENCES `Pass`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passId",
+            "columnName": "passId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fileName"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_Attachment_passId",
+            "unique": false,
+            "columnNames": [
+              "passId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Attachment_passId` ON `${TABLE_NAME}` (`passId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Pass",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "passId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9b8302dac1a853d984d923bf8519420e')"
+    ]
+  }
+}

--- a/app/src/main/java/nz/eloque/foss_wallet/model/Attachment.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/Attachment.kt
@@ -3,6 +3,7 @@ package nz.eloque.foss_wallet.model
 import android.content.Context
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import java.io.File
 import java.io.FileOutputStream
@@ -15,6 +16,9 @@ import java.io.FileOutputStream
             childColumns = arrayOf("passId"),
             onDelete = ForeignKey.CASCADE,
         ),
+    ],
+    indices = [
+        Index(value = ["passId"]),
     ],
 )
 data class Attachment(

--- a/app/src/main/java/nz/eloque/foss_wallet/model/Pass.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/model/Pass.kt
@@ -2,6 +2,7 @@ package nz.eloque.foss_wallet.model
 
 import android.content.Context
 import android.location.Location
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import nz.eloque.foss_wallet.model.field.PassField
@@ -26,6 +27,8 @@ data class Pass(
     val hasStrip: Boolean = false,
     val hasThumbnail: Boolean = false,
     val hasFooter: Boolean = false,
+    @ColumnInfo(defaultValue = "0")
+    val hasBackground: Boolean = false,
     /**
      * Device UUID used for updating passes.
      * We use a unique UUID per pass so devices can not be linked across servers from the UUID
@@ -54,6 +57,8 @@ data class Pass(
     fun thumbnailFile(context: Context): File? = coilImageModel(context, "thumbnail", hasThumbnail)
 
     fun footerFile(context: Context): File? = coilImageModel(context, "footer", hasFooter)
+
+    fun backgroundFile(context: Context): File? = coilImageModel(context, "background", hasBackground)
 
     fun contains(query: String): Boolean =
         when {
@@ -101,6 +106,7 @@ data class Pass(
         stripFile(context)?.delete()
         thumbnailFile(context)?.delete()
         footerFile(context)?.delete()
+        backgroundFile(context)?.delete()
         File(context.filesDir, id).delete()
     }
 

--- a/app/src/main/java/nz/eloque/foss_wallet/parsing/PassParser.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/parsing/PassParser.kt
@@ -100,6 +100,7 @@ class PassParser(
             hasStrip = bitmaps.strip != null,
             hasThumbnail = bitmaps.thumbnail != null,
             hasFooter = bitmaps.footer != null,
+            hasBackground = bitmaps.background != null,
             addedAt = addedAt,
             relevantDates = parseRelevantDates(passJson),
             expirationDate = parseExpiration(passJson),

--- a/app/src/main/java/nz/eloque/foss_wallet/persistence/WalletDb.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/persistence/WalletDb.kt
@@ -35,7 +35,7 @@ fun buildDb(context: Context) =
         .build()
 
 @Database(
-    version = 25,
+    version = 26,
     entities = [
         Pass::class, PassMetadata::class, PassLocalization::class, PassGroup::class, Tag::class, PassTagCrossRef::class, Attachment::class,
     ],
@@ -56,6 +56,7 @@ fun buildDb(context: Context) =
         AutoMigration(from = 21, to = 22),
         AutoMigration(from = 22, to = 23),
         AutoMigration(from = 24, to = 25),
+        AutoMigration(from = 25, to = 26),
     ],
     exportSchema = true,
 )

--- a/app/src/main/java/nz/eloque/foss_wallet/persistence/loader/PassLoader.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/persistence/loader/PassLoader.kt
@@ -31,6 +31,7 @@ data class PassBitmaps(
     val strip: Bitmap?,
     val thumbnail: Bitmap?,
     val footer: Bitmap?,
+    val background: Bitmap?,
 ) {
     fun saveToDisk(
         context: Context,
@@ -45,6 +46,7 @@ data class PassBitmaps(
         save(directory, "strip.png", strip)
         save(directory, "thumbnail.png", thumbnail)
         save(directory, "footer.png", footer)
+        save(directory, "background.png", background)
     }
 
     private fun save(
@@ -87,6 +89,7 @@ class PassLoader(
         var strip: Bitmap? = null
         var thumbnail: Bitmap? = null
         var footer: Bitmap? = null
+        var background: Bitmap? = null
         ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
             var entry = zip.nextEntry
             do {
@@ -126,6 +129,10 @@ class PassLoader(
                             footer = chooseBetter(footer, loadImage(baos))
                         }
 
+                        in Regex("background@?.*\\.png") -> {
+                            background = chooseBetter(background, loadImage(baos))
+                        }
+
                         in LOCALIZATION_FILE_REGEX -> {
                             localizations.addAll(parseLocalization(entry.name.substringBefore(".lproj"), baos))
                         }
@@ -138,7 +145,7 @@ class PassLoader(
         }
         // TODO check signature before returning
         if (passJson != null) {
-            val bitmaps = PassBitmaps(icon, logo, strip, thumbnail, footer)
+            val bitmaps = PassBitmaps(icon, logo, strip, thumbnail, footer, background)
             val pass = passParser.parse(passJson, resultingId, bitmaps, addedAt = addedAt)
             return PassLoadResult(PassWithLocalization(pass, localizations.toList()), bitmaps, OriginalPass(bytes))
         } else {

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/CreateView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/CreateView.kt
@@ -113,6 +113,7 @@ fun CreateView(
     var stripUrl by remember { mutableStateOf<Uri?>(null) }
     var thumbnailUrl by remember { mutableStateOf<Uri?>(null) }
     var footerUrl by remember { mutableStateOf<Uri?>(null) }
+    var backgroundUrl by remember { mutableStateOf<Uri?>(null) }
 
     var name by remember { mutableStateOf("") }
     var nameTouched by remember { mutableStateOf(false) }
@@ -553,6 +554,15 @@ fun CreateView(
                                 labelIcon = Icons.Default.Image,
                                 modifier = Modifier.fillMaxWidth(),
                             )
+
+                            ImagePicker(
+                                imageUrl = backgroundUrl,
+                                onClear = { backgroundUrl = null },
+                                onChoose = { backgroundUrl = it },
+                                label = stringResource(R.string.background),
+                                labelIcon = Icons.Default.Image,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
                         }
                     }
                 }
@@ -609,6 +619,7 @@ fun CreateView(
                                     stripUrl = stripUrl,
                                     thumbnailUrl = thumbnailUrl,
                                     footerUrl = footerUrl,
+                                    backgroundUrl = backgroundUrl,
                                 )
                             withContext(Dispatchers.Main) {
                                 isSaving = false

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/CreateViewModel.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/create/CreateViewModel.kt
@@ -63,6 +63,7 @@ class CreateViewModel
             stripUrl: Uri?,
             thumbnailUrl: Uri?,
             footerUrl: Uri?,
+            backgroundUrl: Uri?,
         ): String {
             val pass =
                 PassCreator.create(
@@ -95,6 +96,7 @@ class CreateViewModel
                     strip = loadBitmapFromUrl(context, stripUrl, STRIP_SIZE),
                     thumbnail = loadBitmapFromUrl(context, thumbnailUrl, THUMBNAIL_SIZE),
                     footer = loadBitmapFromUrl(context, footerUrl, FOOTER_SIZE),
+                    background = loadBitmapFromUrl(context, backgroundUrl, BACKGROUND_SIZE),
                 )
 
             passStore.create(
@@ -104,6 +106,7 @@ class CreateViewModel
                         hasStrip = bitmaps.strip != null,
                         hasThumbnail = bitmaps.thumbnail != null,
                         hasFooter = bitmaps.footer != null,
+                        hasBackground = bitmaps.background != null,
                     ),
                 bitmaps = bitmaps,
             )
@@ -147,6 +150,7 @@ class CreateViewModel
             private const val STRIP_SIZE = 1024
             private const val THUMBNAIL_SIZE = 512
             private const val FOOTER_SIZE = 768
+            private const val BACKGROUND_SIZE = 512
         }
 
         suspend fun geocode(query: String): List<GeocodeResult> {

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/scan/ScanViewModel.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/scan/ScanViewModel.kt
@@ -133,6 +133,7 @@ class ScanViewModel
                     strip = null,
                     thumbnail = null,
                     footer = null,
+                    background = null,
                 )
 
             passStore.create(
@@ -142,6 +143,7 @@ class ScanViewModel
                         hasStrip = bitmaps.strip != null,
                         hasThumbnail = bitmaps.thumbnail != null,
                         hasFooter = bitmaps.footer != null,
+                        hasBackground = bitmaps.background != null,
                     ),
                 bitmaps = bitmaps,
             )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,7 @@
     <string name="strip">Strip</string>
     <string name="thumbnail">Thumbnail</string>
     <string name="footer">Footer</string>
+    <string name="background">Background</string>
     <string name="no_url_in_clipboard">No URL in clipboard</string>
     <string name="no_text_in_clipboard">No text in clipboard</string>
     <string name="barcode_value_invalid">The given value is not a valid %1$s code</string>


### PR DESCRIPTION
Apple Wallet uses this image as the background behind the content of an event ticket with a blur effect applied. The background image is the only image of a pass that has not been saved when adding a new pass. This will be need for my next PR which will improve the layout of the different pass cards depending on the type of the pass.

In addition to that I fixed the room waring of a missing index on a foreign key child in the `Attachment` class.