### PR TITLE
Fix vertical alignment of the pass in the pass screen

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/pass/PassScreen.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/pass/PassScreen.kt
@@ -138,6 +138,7 @@ fun PassScreen(
                         state = pagerState,
                         modifier = Modifier.fillMaxSize(),
                         pageSpacing = 8.dp,
+                        verticalAlignment = Alignment.Top,
                     ) { page ->
                         val pagePass = passes[page]
                         PassView(


### PR DESCRIPTION
Tiny fix to prevent a center aligned pass in the pass screen when the height of the pass and its back fields are smaller than the height of the screen. (The `HorizontalPager()` Composable aligns its content in the center by default.)