### PR TITLE
Persist tag filter and filter panel visibility in wallet view

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/persistence/SettingsStore.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/persistence/SettingsStore.kt
@@ -17,6 +17,8 @@ private const val SYNC_ENABLED = "syncEnabled"
 private const val BARCODE_POSITION = "barcodePosition"
 private const val PASS_VIEW_BRIGHTNESS = "passViewBrightness"
 private const val SORT_OPTION = "walletViewSortOption"
+private const val TAG_FILTER = "walletViewTagFilter"
+private const val FILTERS_EXPANDED = "walletViewFiltersExpanded"
 private const val DELETE_CONFIRMATION_ENABLED = "deleteConfirmationEnabled"
 
 sealed class BarcodePosition(
@@ -73,6 +75,17 @@ class SettingsStore
         fun sortOption(): SortOption = SortOptionSerializer.deserialize(prefs.getString(SORT_OPTION, "")!!) ?: SortOption.TimeAdded
 
         fun setSortOption(sortOption: SortOption) = prefs.edit { putString(SORT_OPTION, SortOptionSerializer.serialize(sortOption)) }
+
+        fun tagFilter(): String? = prefs.getString(TAG_FILTER, null)
+
+        fun setTagFilter(label: String?) =
+            prefs.edit {
+                if (label == null) remove(TAG_FILTER) else putString(TAG_FILTER, label)
+            }
+
+        fun filtersExpanded(): Boolean = prefs.getBoolean(FILTERS_EXPANDED, false)
+
+        fun setFiltersExpanded(expanded: Boolean) = prefs.edit { putBoolean(FILTERS_EXPANDED, expanded) }
 
         fun deleteConfirmationEnabled(): Boolean = prefs.getBoolean(DELETE_CONFIRMATION_ENABLED, true)
 

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/FilterBlock.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/FilterBlock.kt
@@ -18,11 +18,8 @@ import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -45,11 +42,11 @@ fun FilterBlock(
     onSortChange: (SortOption) -> Unit,
     passTypesToShow: SnapshotStateList<PassType>,
     tags: Set<Tag>,
-    tagToFilterFor: MutableState<Tag?>,
+    selectedTag: Tag?,
 ) {
     val resources = LocalResources.current
 
-    var filtersShown by remember { mutableStateOf(false) }
+    val filtersShown by walletViewModel.filtersExpandedState.collectAsState()
 
     Column {
         Row(
@@ -72,7 +69,7 @@ fun FilterBlock(
                 optionLabel = { resources.getString(it.l18n) },
             )
             IconButton(onClick = {
-                filtersShown = !filtersShown
+                walletViewModel.setFiltersExpanded(!filtersShown)
             }) {
                 if (filtersShown) {
                     Icon(imageVector = Icons.Default.KeyboardArrowUp, contentDescription = stringResource(R.string.collapse))
@@ -108,9 +105,9 @@ fun FilterBlock(
                 )
                 TagRow(
                     tags = tags,
-                    selectedTag = tagToFilterFor.value,
-                    onTagSelected = { tagToFilterFor.value = it },
-                    onTagDeselected = { tagToFilterFor.value = null },
+                    selectedTag = selectedTag,
+                    onTagSelected = { walletViewModel.setTagFilter(it) },
+                    onTagDeselected = { walletViewModel.setTagFilter(null) },
                     walletViewModel = walletViewModel,
                     modifier = Modifier.fillMaxWidth(),
                 )

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletView.kt
@@ -51,7 +51,6 @@ import nz.eloque.compose_kit.components.SwipeToDismiss
 import nz.eloque.foss_wallet.R
 import nz.eloque.foss_wallet.model.LocalizedPassWithTags
 import nz.eloque.foss_wallet.model.PassType
-import nz.eloque.foss_wallet.model.Tag
 import nz.eloque.foss_wallet.ui.Screen
 import nz.eloque.foss_wallet.ui.card.ShortPassCard
 import nz.eloque.foss_wallet.ui.components.GroupCard
@@ -87,13 +86,14 @@ fun WalletView(
 
     val sortOption = walletViewModel.sortOptionState.collectAsState().value
 
-    val tagToFilterFor = remember { mutableStateOf<Tag?>(null) }
+    val tagFilterLabel by walletViewModel.tagFilterState.collectAsState()
+    val tagToFilterFor = tags.firstOrNull { it.label == tagFilterLabel }
     val passToDelete = remember { mutableStateOf<LocalizedPassWithTags?>(null) }
 
     val sortedPasses =
         passes
             .filter { localizedPass -> passTypesToShow.any { localizedPass.pass.type.isSameType(it) } }
-            .filter { localizedPass -> tagToFilterFor.value == null || localizedPass.tags.contains(tagToFilterFor.value) }
+            .filter { localizedPass -> tagToFilterFor == null || localizedPass.tags.contains(tagToFilterFor) }
             .sortedWith(sortOption.comparator)
             .groupBy { it.metadata.groupId }
             .toList()
@@ -155,7 +155,7 @@ fun WalletView(
                 onSortChange = { walletViewModel.setSortOption(it) },
                 passTypesToShow = passTypesToShow,
                 tags = tags,
-                tagToFilterFor = tagToFilterFor,
+                selectedTag = tagToFilterFor,
             )
         }
 

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletViewModel.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/wallet/WalletViewModel.kt
@@ -46,6 +46,12 @@ class WalletViewModel
         private val _sortOptionState: MutableStateFlow<SortOption> = MutableStateFlow(SortOption.TimeAdded)
         val sortOptionState = _sortOptionState.asStateFlow()
 
+        private val _tagFilterState: MutableStateFlow<String?> = MutableStateFlow(null)
+        val tagFilterState = _tagFilterState.asStateFlow()
+
+        private val _filtersExpandedState: MutableStateFlow<Boolean> = MutableStateFlow(false)
+        val filtersExpandedState = _filtersExpandedState.asStateFlow()
+
         init {
             update()
             viewModelScope.launch(Dispatchers.IO) {
@@ -56,12 +62,24 @@ class WalletViewModel
         private fun update() {
             viewModelScope.launch {
                 _sortOptionState.value = settingsStore.sortOption()
+                _tagFilterState.value = settingsStore.tagFilter()
+                _filtersExpandedState.value = settingsStore.filtersExpanded()
             }
         }
 
         fun setSortOption(sortOption: SortOption) {
             settingsStore.setSortOption(sortOption)
             update()
+        }
+
+        fun setTagFilter(tag: Tag?) {
+            settingsStore.setTagFilter(tag?.label)
+            _tagFilterState.value = tag?.label
+        }
+
+        fun setFiltersExpanded(expanded: Boolean) {
+            settingsStore.setFiltersExpanded(expanded)
+            _filtersExpandedState.value = expanded
         }
 
         fun group(passes: Set<Pass>) = viewModelScope.launch(Dispatchers.IO) { passStore.group(passes) }


### PR DESCRIPTION
## Problem

The tag filter and the expanded/collapsed state of the filter panel in the wallet view are held in transient composable state, so both reset whenever the wallet screen is recreated e.g. when navigating back from a pass or after an app restart. If you routinely filter by the same tag, you have to re-expand the panel and re-select the tag every time.

## Solution

Store both in `SettingsStore` (SharedPreferences), following the existing pattern used for the sort option:

- `SettingsStore`: new `walletViewTagFilter` and `walletViewFiltersExpanded` preferences
- `WalletViewModel`: exposes both as `StateFlow`s, loaded on init and written through on change
- `WalletView`/`FilterBlock`: read/write the persisted state instead of local `remember` state; the selected tag is resolved by label, so a deleted tag simply falls back to no filter

The selection now persists until the user deselects the tag or collapses the panel themselves.

## Testing

- `./gradlew ktlintCheck testDebugUnitTest` passes locally

Fixes #665
