### PR TITLE
Add theme selector and pure black (OLED) dark theme

### DIFF
--- a/app/src/main/java/nz/eloque/foss_wallet/MainActivity.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -26,10 +27,12 @@ import androidx.navigation.compose.rememberNavController
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberPermissionState
 import dagger.hilt.android.AndroidEntryPoint
+import jakarta.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import nz.eloque.foss_wallet.persistence.SettingsStore
 import nz.eloque.foss_wallet.persistence.loader.Loader
 import nz.eloque.foss_wallet.persistence.loader.LoaderResult
 import nz.eloque.foss_wallet.shortcut.Shortcut
@@ -43,6 +46,9 @@ import nz.eloque.foss_wallet.ui.theme.WalletTheme
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private val walletViewModel: WalletViewModel by viewModels()
+
+    @Inject
+    lateinit var settingsStore: SettingsStore
 
     @OptIn(ExperimentalPermissionsApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -124,7 +130,8 @@ class MainActivity : ComponentActivity() {
                     coroutineScope.launch(Dispatchers.IO) { permissionState.launchPermissionRequest() }
                 }
             }
-            WalletTheme {
+            val oledDark by settingsStore.oledDarkState.collectAsState()
+            WalletTheme(oledDark = oledDark) {
                 Box(
                     modifier =
                         androidx.compose.ui.Modifier

--- a/app/src/main/java/nz/eloque/foss_wallet/MainActivity.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
@@ -33,6 +34,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import nz.eloque.foss_wallet.persistence.SettingsStore
+import nz.eloque.foss_wallet.persistence.ThemeMode
 import nz.eloque.foss_wallet.persistence.loader.Loader
 import nz.eloque.foss_wallet.persistence.loader.LoaderResult
 import nz.eloque.foss_wallet.shortcut.Shortcut
@@ -131,7 +133,14 @@ class MainActivity : ComponentActivity() {
                 }
             }
             val oledDark by settingsStore.oledDarkState.collectAsState()
-            WalletTheme(oledDark = oledDark) {
+            val themeMode by settingsStore.themeModeState.collectAsState()
+            val darkTheme =
+                when (themeMode) {
+                    ThemeMode.Light -> false
+                    ThemeMode.Dark -> true
+                    else -> isSystemInDarkTheme()
+                }
+            WalletTheme(darkTheme = darkTheme, oledDark = oledDark) {
                 Box(
                     modifier =
                         androidx.compose.ui.Modifier

--- a/app/src/main/java/nz/eloque/foss_wallet/persistence/SettingsStore.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/persistence/SettingsStore.kt
@@ -5,6 +5,10 @@ import androidx.annotation.StringRes
 import androidx.compose.ui.Alignment
 import androidx.core.content.edit
 import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import nz.eloque.foss_wallet.R
 import nz.eloque.foss_wallet.model.SortOption
 import nz.eloque.foss_wallet.model.SortOptionSerializer
@@ -18,6 +22,7 @@ private const val BARCODE_POSITION = "barcodePosition"
 private const val PASS_VIEW_BRIGHTNESS = "passViewBrightness"
 private const val SORT_OPTION = "walletViewSortOption"
 private const val DELETE_CONFIRMATION_ENABLED = "deleteConfirmationEnabled"
+private const val OLED_DARK = "oledDarkTheme"
 
 sealed class BarcodePosition(
     val alignment: Alignment,
@@ -43,11 +48,22 @@ sealed class BarcodePosition(
     }
 }
 
+@Singleton
 class SettingsStore
     @Inject
     constructor(
         private val prefs: SharedPreferences,
     ) {
+        private val _oledDarkState = MutableStateFlow(prefs.getBoolean(OLED_DARK, false))
+        val oledDarkState: StateFlow<Boolean> = _oledDarkState.asStateFlow()
+
+        fun oledDark(): Boolean = prefs.getBoolean(OLED_DARK, false)
+
+        fun setOledDark(enabled: Boolean) {
+            prefs.edit { putBoolean(OLED_DARK, enabled) }
+            _oledDarkState.value = enabled
+        }
+
         fun isSyncEnabled(): Boolean = prefs.getBoolean(SYNC_ENABLED, false)
 
         fun enableSync(enabled: Boolean) = prefs.edit { putBoolean(SYNC_ENABLED, enabled) }

--- a/app/src/main/java/nz/eloque/foss_wallet/persistence/SettingsStore.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/persistence/SettingsStore.kt
@@ -23,6 +23,7 @@ private const val PASS_VIEW_BRIGHTNESS = "passViewBrightness"
 private const val SORT_OPTION = "walletViewSortOption"
 private const val DELETE_CONFIRMATION_ENABLED = "deleteConfirmationEnabled"
 private const val OLED_DARK = "oledDarkTheme"
+private const val THEME_MODE = "themeMode"
 
 sealed class BarcodePosition(
     val alignment: Alignment,
@@ -48,6 +49,28 @@ sealed class BarcodePosition(
     }
 }
 
+sealed class ThemeMode(
+    val key: String,
+    @param:StringRes val label: Int,
+) {
+    object System : ThemeMode("SYSTEM", R.string.theme_system)
+
+    object Light : ThemeMode("LIGHT", R.string.theme_light)
+
+    object Dark : ThemeMode("DARK", R.string.theme_dark)
+
+    companion object {
+        fun all(): List<ThemeMode> = listOf(System, Light, Dark)
+
+        fun of(representation: String): ThemeMode =
+            when (representation) {
+                Light.key -> Light
+                Dark.key -> Dark
+                else -> System
+            }
+    }
+}
+
 @Singleton
 class SettingsStore
     @Inject
@@ -62,6 +85,17 @@ class SettingsStore
         fun setOledDark(enabled: Boolean) {
             prefs.edit { putBoolean(OLED_DARK, enabled) }
             _oledDarkState.value = enabled
+        }
+
+        private val _themeModeState: MutableStateFlow<ThemeMode> =
+            MutableStateFlow(ThemeMode.of(prefs.getString(THEME_MODE, ThemeMode.System.key)!!))
+        val themeModeState: StateFlow<ThemeMode> = _themeModeState.asStateFlow()
+
+        fun themeMode(): ThemeMode = ThemeMode.of(prefs.getString(THEME_MODE, ThemeMode.System.key)!!)
+
+        fun setThemeMode(themeMode: ThemeMode) {
+            prefs.edit { putString(THEME_MODE, themeMode.key) }
+            _themeModeState.value = themeMode
         }
 
         fun isSyncEnabled(): Boolean = prefs.getBoolean(SYNC_ENABLED, false)

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/settings/SettingsView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/settings/SettingsView.kt
@@ -38,6 +38,7 @@ import nz.eloque.compose_kit.settings.SettingsButton
 import nz.eloque.compose_kit.settings.SettingsSwitch
 import nz.eloque.foss_wallet.R
 import nz.eloque.foss_wallet.persistence.BarcodePosition
+import nz.eloque.foss_wallet.persistence.ThemeMode
 import nz.eloque.foss_wallet.share.share
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -116,6 +117,18 @@ fun SettingsView(settingsViewModel: SettingsViewModel) {
         Section(
             heading = stringResource(R.string.appearance),
         ) {
+            ComboBox(
+                title = stringResource(R.string.theme),
+                options = ThemeMode.all(),
+                selectedOption = settings.value.themeMode,
+                onOptionSelected = {
+                    coroutineScope.launch(Dispatchers.IO) {
+                        settingsViewModel.setThemeMode(it)
+                    }
+                },
+                optionLabel = { resources.getString(it.label) },
+            )
+            HorizontalDivider()
             SettingsSwitch(
                 title = stringResource(R.string.oled_dark_theme),
                 subtitle = stringResource(R.string.oled_dark_theme_hint),

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/settings/SettingsView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/settings/SettingsView.kt
@@ -118,6 +118,7 @@ fun SettingsView(settingsViewModel: SettingsViewModel) {
         ) {
             SettingsSwitch(
                 title = stringResource(R.string.oled_dark_theme),
+                subtitle = stringResource(R.string.oled_dark_theme_hint),
                 checked = settings.value.oledDark,
                 onCheckedChange = { coroutineScope.launch(Dispatchers.IO) { settingsViewModel.setOledDark(it) } },
             )

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/settings/SettingsView.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/settings/SettingsView.kt
@@ -114,6 +114,15 @@ fun SettingsView(settingsViewModel: SettingsViewModel) {
             )
         }
         Section(
+            heading = stringResource(R.string.appearance),
+        ) {
+            SettingsSwitch(
+                title = stringResource(R.string.oled_dark_theme),
+                checked = settings.value.oledDark,
+                onCheckedChange = { coroutineScope.launch(Dispatchers.IO) { settingsViewModel.setOledDark(it) } },
+            )
+        }
+        Section(
             heading = stringResource(R.string.delete),
         ) {
             SettingsSwitch(

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/settings/SettingsViewModel.kt
@@ -23,6 +23,7 @@ data class SettingsUiState(
     val barcodePosition: BarcodePosition = BarcodePosition.Center,
     val increasePassViewBrightness: Boolean = false,
     val askBeforeDelete: Boolean = true,
+    val oledDark: Boolean = false,
 )
 
 @HiltViewModel
@@ -51,6 +52,7 @@ class SettingsViewModel
                         barcodePosition = settingsStore.barcodePosition(),
                         increasePassViewBrightness = settingsStore.increasePassViewBrightness(),
                         askBeforeDelete = settingsStore.deleteConfirmationEnabled(),
+                        oledDark = settingsStore.oledDark(),
                     )
             }
         }
@@ -85,6 +87,11 @@ class SettingsViewModel
 
         fun setAskBeforeDelete(enabled: Boolean) {
             settingsStore.setDeleteConfirmationEnabled(enabled)
+            update()
+        }
+
+        fun setOledDark(enabled: Boolean) {
+            settingsStore.setOledDark(enabled)
             update()
         }
     }

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/screens/settings/SettingsViewModel.kt
@@ -13,6 +13,7 @@ import nz.eloque.foss_wallet.api.UpdateScheduler
 import nz.eloque.foss_wallet.persistence.BarcodePosition
 import nz.eloque.foss_wallet.persistence.PassStore
 import nz.eloque.foss_wallet.persistence.SettingsStore
+import nz.eloque.foss_wallet.persistence.ThemeMode
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -24,6 +25,7 @@ data class SettingsUiState(
     val increasePassViewBrightness: Boolean = false,
     val askBeforeDelete: Boolean = true,
     val oledDark: Boolean = false,
+    val themeMode: ThemeMode = ThemeMode.System,
 )
 
 @HiltViewModel
@@ -53,6 +55,7 @@ class SettingsViewModel
                         increasePassViewBrightness = settingsStore.increasePassViewBrightness(),
                         askBeforeDelete = settingsStore.deleteConfirmationEnabled(),
                         oledDark = settingsStore.oledDark(),
+                        themeMode = settingsStore.themeMode(),
                     )
             }
         }
@@ -92,6 +95,11 @@ class SettingsViewModel
 
         fun setOledDark(enabled: Boolean) {
             settingsStore.setOledDark(enabled)
+            update()
+        }
+
+        fun setThemeMode(themeMode: ThemeMode) {
+            settingsStore.setThemeMode(themeMode)
             update()
         }
     }

--- a/app/src/main/java/nz/eloque/foss_wallet/ui/theme/Theme.kt
+++ b/app/src/main/java/nz/eloque/foss_wallet/ui/theme/Theme.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
@@ -43,6 +44,7 @@ onSurface = Color(0xFF1C1B1F),
 fun WalletTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     dynamicColor: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S,
+    oledDark: Boolean = false,
     content: @Composable () -> Unit,
 ) {
     val colorScheme =
@@ -54,6 +56,16 @@ fun WalletTheme(
 
             darkTheme -> DarkColorScheme
             else -> LightColorScheme
+        }.let {
+            if (darkTheme && oledDark) {
+                it.copy(
+                    background = Color.Black,
+                    surface = Color.Black,
+                    surfaceContainerLowest = Color.Black,
+                )
+            } else {
+                it
+            }
         }
     val view = LocalView.current
     if (!view.isInEditMode) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,6 +130,8 @@
     <string name="no_map_app_found">No map app found</string>
     <string name="no_calendar_app_found">No calendar app found</string>
     <string name="created_pass_export_warning">Created passes can currently not be exported</string>
+    <string name="appearance">Appearance</string>
+    <string name="oled_dark_theme">Pure black dark theme (OLED)</string>
     <string name="show_archived_passes">Show archived passes</string>
     <string name="permission_read_passes_label">Read Passes</string>
     <string name="permission_read_passes_description">Read your passes and their details, including barcodes in a Catima compatible way</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,10 @@
     <string name="no_calendar_app_found">No calendar app found</string>
     <string name="created_pass_export_warning">Created passes can currently not be exported</string>
     <string name="appearance">Appearance</string>
+    <string name="theme">Theme</string>
+    <string name="theme_system">Follow system</string>
+    <string name="theme_light">Light</string>
+    <string name="theme_dark">Dark</string>
     <string name="oled_dark_theme">Pure black dark theme (OLED)</string>
     <string name="oled_dark_theme_hint">Applies when dark mode is on</string>
     <string name="show_archived_passes">Show archived passes</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,6 +132,7 @@
     <string name="created_pass_export_warning">Created passes can currently not be exported</string>
     <string name="appearance">Appearance</string>
     <string name="oled_dark_theme">Pure black dark theme (OLED)</string>
+    <string name="oled_dark_theme_hint">Applies when dark mode is on</string>
     <string name="show_archived_passes">Show archived passes</string>
     <string name="permission_read_passes_label">Read Passes</string>
     <string name="permission_read_passes_description">Read your passes and their details, including barcodes in a Catima compatible way</string>


### PR DESCRIPTION
## Summary

Adds an **Appearance** section to settings with two related options:

**Theme selector (Follow system / Light / Dark)**
- The app previously always followed the system day/night setting; now the user can force either theme
- Implemented with the same sealed-class pattern as `BarcodePosition`, applied in `MainActivity` when choosing the color scheme

**Pure black dark theme for OLED screens (#619)**
- When enabled and the effective theme is dark, `background`, `surface`, and `surfaceContainerLowest` become pure black (works with both dynamic color and the static dark scheme); elevated surfaces like cards keep their tone for contrast
- A subtitle under the switch notes that it applies when dark mode is on
- Light mode is unaffected

Both settings are exposed as `StateFlow`s from `SettingsStore` (now `@Singleton`), so changes apply immediately without a restart.

Fixes #619

## Testing

- `./gradlew ktlintCheck testDebugUnitTest` passes locally
- Verified on a Pixel 9a emulator:
  - With dark mode on and the OLED switch enabled, the wallet background is pure black (checked screenshot pixels are RGB 0,0,0)
  - With the system in light mode, selecting Theme: Dark switches the whole app to the dark theme instantly; Follow system restores the old behavior
